### PR TITLE
refactor: full architecture debt cleanup (v1.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-04-12
+
+### Changed
+
+- **Architecture debt fully resolved** (ARCHITECTURE_RESEARCH.md §10,
+  all 7 items closed):
+  - **10.1** `LightEntity.LINKABLE_ROLES` now accepts battery / signal
+    linked sensors (was empty tuple).
+  - **10.2** `_publish_config` / `_publish_states` now route through
+    `MqttClientService.publish()` instead of raw `_mqtt_client` access.
+  - **10.3** `SberCommandDispatcher` takes `BridgeCommandContext` Protocol
+    instead of full `SberBridge` reference — explicit, narrow coupling.
+  - **10.4** Extracted `ReconnectAckGuard` component (`reconnect_ack_guard.py`)
+    from scattered bridge fields.
+  - **10.5** Hardcoded `1.5s` in `_delayed_confirm` → configurable
+    `CONF_CONFIRM_DELAY` in `SETTINGS_DEFAULTS`.
+  - **10.6** `process_cmd` returns `list[CommandResult]` (union of
+    `ServiceCallResult | UpdateStateResult` TypedDicts) instead of
+    untyped `list[dict]`. Applied across all 14 device classes.
+  - **10.7** All 8 complex device classes migrated to declarative
+    `AttrSpec` (extended with `converter` field for full-attrs access):
+    tv, hvac_fan, hvac_air_purifier, humidifier, kettle,
+    vacuum_cleaner, light, climate.
+
 ## [1.26.1] - 2026-04-12
 
 ### Fixed

--- a/custom_components/sber_mqtt_bridge/command_dispatcher.py
+++ b/custom_components/sber_mqtt_bridge/command_dispatcher.py
@@ -13,12 +13,12 @@ operations.  The coupling is explicit and one-way.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
-import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from homeassistant.core import Context
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import (
     HomeAssistantError,
     ServiceNotFound,
@@ -29,7 +29,43 @@ from homeassistant.exceptions import (
 from .sber_protocol import parse_sber_command, parse_sber_status_request
 
 if TYPE_CHECKING:
-    from .sber_bridge import SberBridge
+    from .devices.base_entity import BaseEntity
+    from .reconnect_ack_guard import ReconnectAckGuard
+
+
+class _BridgeStats(Protocol):
+    """Minimal stats interface used by the dispatcher."""
+
+    commands_received: int
+    status_requests: int
+    config_requests: int
+    errors_from_sber: int
+    acknowledged_entities: set[str]
+
+
+@runtime_checkable
+class BridgeCommandContext(Protocol):
+    """Narrow interface for SberCommandDispatcher's bridge dependency.
+
+    Replaces the full ``SberBridge`` reference to make the coupling
+    explicit and testable.  Every field/method the dispatcher touches
+    is declared here.
+    """
+
+    _hass: HomeAssistant
+    _stats: _BridgeStats
+    _ack_guard: ReconnectAckGuard
+    _entities: dict[str, BaseEntity]
+    _enabled_entity_ids: list[str]
+    _redefinitions: dict[str, dict]
+    _confirm_tasks: dict[str, asyncio.Task]
+
+    async def _publish_states(self, ids: list[str] | None, *, force: bool = False) -> None: ...
+    async def _publish_config(self, entity_ids: list[str] | None = None) -> None: ...
+    def _persist_redefinitions(self) -> None: ...
+    def _create_safe_task(self, coro: object, name: str = "") -> asyncio.Task: ...
+    async def _delayed_confirm(self, entity_id: str) -> None: ...
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,8 +78,8 @@ class SberCommandDispatcher:
     incoming messages to the matching handler.
     """
 
-    def __init__(self, bridge: SberBridge) -> None:
-        """Initialize the dispatcher bound to a bridge instance."""
+    def __init__(self, bridge: BridgeCommandContext) -> None:
+        """Initialize the dispatcher bound to a bridge context."""
         self._bridge = bridge
 
     async def handle_command(self, payload: bytes) -> None:
@@ -59,10 +95,9 @@ class SberCommandDispatcher:
 
         devices = data.get("devices", {})
 
-        if bridge._awaiting_sber_ack:
-            if time.monotonic() >= bridge._awaiting_sber_ack_deadline:
-                _LOGGER.info("Sber ack timeout reached — accepting commands")
-                bridge._awaiting_sber_ack = False
+        if bridge._ack_guard.is_awaiting:
+            if bridge._ack_guard.timeout_check():
+                pass  # Guard cleared by timeout — fall through to process
             else:
                 entity_ids = [eid for eid in devices if eid in bridge._entities]
                 _LOGGER.warning(
@@ -159,9 +194,7 @@ class SberCommandDispatcher:
         requested_ids = parse_sber_status_request(payload)
         bridge._stats.status_requests += 1
 
-        if bridge._awaiting_sber_ack:
-            bridge._awaiting_sber_ack = False
-            _LOGGER.info("Sber ack received (status_request) — now accepting commands")
+        bridge._ack_guard.acknowledge()
 
         if requested_ids:
             unknown = [eid for eid in requested_ids if eid not in bridge._entities and eid != "root"]
@@ -193,9 +226,7 @@ class SberCommandDispatcher:
         """Handle config request from Sber cloud — send device list."""
         bridge = self._bridge
         bridge._stats.config_requests += 1
-        if bridge._awaiting_sber_ack:
-            bridge._awaiting_sber_ack = False
-            _LOGGER.info("Sber ack received (config_request) — now accepting commands")
+        bridge._ack_guard.acknowledge()
         _LOGGER.info(
             "Sber config request received (will publish %d entities)",
             len(bridge._enabled_entity_ids),

--- a/custom_components/sber_mqtt_bridge/const.py
+++ b/custom_components/sber_mqtt_bridge/const.py
@@ -53,6 +53,9 @@ CONF_CONTEXT_CLEANUP_THRESHOLD = "context_cleanup_threshold"
 CONF_HUB_AUTO_PARENT = "hub_auto_parent_id"
 """Options key for auto-assigning parent_id=root to all child devices."""
 
+CONF_CONFIRM_DELAY = "confirm_delay"
+"""Options key for delay (seconds) before confirming state back to Sber after a command."""
+
 SETTINGS_DEFAULTS: dict[str, int | float | bool] = {
     CONF_RECONNECT_MIN: 5,
     CONF_RECONNECT_MAX: 300,
@@ -62,6 +65,7 @@ SETTINGS_DEFAULTS: dict[str, int | float | bool] = {
     CONF_CONTEXT_CLEANUP_THRESHOLD: 200,
     CONF_SBER_VERIFY_SSL: True,
     CONF_HUB_AUTO_PARENT: False,
+    CONF_CONFIRM_DELAY: 1.5,
 }
 """Default values for bridge operational settings."""
 

--- a/custom_components/sber_mqtt_bridge/devices/base_entity.py
+++ b/custom_components/sber_mqtt_bridge/devices/base_entity.py
@@ -72,10 +72,14 @@ class AttrSpec:
     """
 
     field: str
-    attr_keys: tuple[str, ...]
+    attr_keys: tuple[str, ...] = ()
     parser: Callable[[object], object] = lambda v: v
     default: object = None
     preserve_on_missing: bool = False
+    converter: Callable[[dict], object] | None = None
+    """Full-attrs converter.  When set, receives the entire HA attributes dict
+    instead of a single value looked up by ``attr_keys``.  ``parser`` and
+    ``attr_keys`` are ignored when ``converter`` is provided."""
 
 
 def _safe_int_parser(value: object) -> int | None:
@@ -321,6 +325,18 @@ class BaseEntity(ABC):
             attrs: HA attributes dict extracted from a state dict.
         """
         for spec in self.ATTR_SPECS:
+            # Full-attrs converter path: receives entire attrs dict
+            if spec.converter is not None:
+                try:
+                    parsed = spec.converter(attrs)
+                except (TypeError, ValueError, KeyError):
+                    parsed = spec.default
+                if parsed is None and spec.preserve_on_missing:
+                    continue
+                setattr(self, spec.field, parsed if parsed is not None else spec.default)
+                continue
+
+            # Standard path: look up single value by attr_keys
             raw: object = None
             for key in spec.attr_keys:
                 candidate = attrs.get(key)

--- a/custom_components/sber_mqtt_bridge/devices/base_entity.py
+++ b/custom_components/sber_mqtt_bridge/devices/base_entity.py
@@ -16,6 +16,36 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
 from ..sber_constants import SERVICE_CALL_TYPE, SERVICE_TURN_OFF, SERVICE_TURN_ON
 
+# ---------------------------------------------------------------------------
+#  Typed command result types for process_cmd return values
+# ---------------------------------------------------------------------------
+
+
+class ServiceCallUrl(TypedDict, total=False):
+    """Descriptor for a single HA service call."""
+
+    type: str
+    domain: str
+    service: str
+    target: dict
+    service_data: dict
+
+
+class ServiceCallResult(TypedDict):
+    """A process_cmd result instructing the bridge to call a HA service."""
+
+    url: ServiceCallUrl
+
+
+class UpdateStateResult(TypedDict):
+    """A process_cmd result instructing the bridge to re-publish current state."""
+
+    update_state: bool
+
+
+CommandResult = ServiceCallResult | UpdateStateResult
+"""Union type for all possible process_cmd return items."""
+
 
 @dataclass(frozen=True, slots=True)
 class AttrSpec:
@@ -557,7 +587,7 @@ class BaseEntity(ABC):
         service: str,
         entity_id: str,
         service_data: dict | None = None,
-    ) -> dict:
+    ) -> ServiceCallResult:
         """Build a HA service call dict for Sber → HA forwarding.
 
         This is the canonical helper for all device ``process_cmd`` methods.
@@ -584,7 +614,7 @@ class BaseEntity(ABC):
         return {"url": url}
 
     @classmethod
-    def _build_on_off_service_call(cls, entity_id: str, domain: str, on: bool) -> dict:
+    def _build_on_off_service_call(cls, entity_id: str, domain: str, on: bool) -> ServiceCallResult:
         """Build a HA turn_on / turn_off service call dict.
 
         Convenience wrapper over :meth:`_build_service_call` for the common
@@ -601,15 +631,15 @@ class BaseEntity(ABC):
         return cls._build_service_call(domain, SERVICE_TURN_ON if on else SERVICE_TURN_OFF, entity_id)
 
     @abstractmethod
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process a command from Sber cloud.
 
         Args:
             cmd_data: Command payload with 'states' list, or None.
 
         Returns:
-            List of dicts with 'url' key containing HA service call descriptors,
-            or empty list if no action needed or cmd_data is None.
+            List of :class:`ServiceCallResult` or :class:`UpdateStateResult`
+            items, or empty list if no action needed or cmd_data is None.
         """
         return []
 

--- a/custom_components/sber_mqtt_bridge/devices/climate.py
+++ b/custom_components/sber_mqtt_bridge/devices/climate.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Callable
+from typing import ClassVar
 
 from ..sber_constants import SberFeature
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import ROLE_TEMPERATURE, BaseEntity, CommandResult
+from .base_entity import (
+    ROLE_TEMPERATURE,
+    AttrSpec,
+    BaseEntity,
+    CommandResult,
+    _safe_float_parser,
+    _safe_int_parser,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -108,6 +116,21 @@ HA_TO_SBER_FAN_MODE: dict[str, str] = {
 """Map HA fan modes to Sber air flow power enum values."""
 
 
+def _finite_float_parser(value: object) -> float | None:
+    """Parse a value to float, returning None for non-finite results (NaN, Inf)."""
+    parsed = _safe_float_parser(value)
+    if parsed is not None and math.isfinite(parsed):
+        return parsed
+    return None
+
+
+def _safe_bool_or_none(value: object) -> bool | None:
+    """Parse to bool preserving None (for child_lock detection)."""
+    if value is None:
+        return None
+    return bool(value)
+
+
 class ClimateEntity(BaseEntity):
     """Sber climate entity for air conditioner control.
 
@@ -125,6 +148,73 @@ class ClimateEntity(BaseEntity):
     """
 
     LINKABLE_ROLES = (ROLE_TEMPERATURE,)
+
+    ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = (
+        AttrSpec(
+            field="temperature",
+            attr_keys=("current_temperature",),
+            parser=_finite_float_parser,
+        ),
+        AttrSpec(
+            field="target_temperature",
+            attr_keys=("temperature",),
+            parser=_finite_float_parser,
+        ),
+        AttrSpec(
+            field="fan_modes",
+            converter=lambda attrs: attrs.get("fan_modes") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="swing_modes",
+            converter=lambda attrs: attrs.get("swing_modes") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="hvac_modes",
+            converter=lambda attrs: attrs.get("hvac_modes") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="fan_mode",
+            attr_keys=("fan_mode",),
+        ),
+        AttrSpec(
+            field="swing_mode",
+            attr_keys=("swing_mode",),
+        ),
+        AttrSpec(
+            field="min_temp",
+            attr_keys=("min_temp",),
+            parser=_safe_float_parser,
+            default=16.0,
+        ),
+        AttrSpec(
+            field="max_temp",
+            attr_keys=("max_temp",),
+            parser=_safe_float_parser,
+            default=32.0,
+        ),
+        AttrSpec(
+            field="_target_humidity",
+            attr_keys=("target_humidity",),
+            parser=_safe_int_parser,
+        ),
+        AttrSpec(
+            field="_preset_mode",
+            attr_keys=("preset_mode",),
+        ),
+        AttrSpec(
+            field="_preset_modes",
+            converter=lambda attrs: attrs.get("preset_modes") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="_child_lock",
+            attr_keys=("child_lock",),
+            parser=_safe_bool_or_none,
+        ),
+    )
 
     _supports_fan: bool = True
     _supports_swing: bool = True
@@ -169,6 +259,11 @@ class ClimateEntity(BaseEntity):
     def fill_by_ha_state(self, ha_state: dict) -> None:
         """Parse HA state and update all climate attributes.
 
+        Simple attribute extraction is handled declaratively via
+        :attr:`ATTR_SPECS`.  State-derived values (``current_state``,
+        ``hvac_mode``) remain here since they come from the top-level
+        ``state`` field, not from ``attributes``.
+
         Args:
             ha_state: HA state dict with 'state' and 'attributes' keys.
                 Attributes may include current_temperature, temperature,
@@ -176,32 +271,12 @@ class ClimateEntity(BaseEntity):
                 preset_mode, preset_modes, etc.
         """
         super().fill_by_ha_state(ha_state)
-        self.current_state = ha_state.get("state", "off") != "off"
         attrs = ha_state.get("attributes", {})
-        raw_temp = self._safe_float(attrs.get("current_temperature"))
-        self.temperature = raw_temp if raw_temp is not None and math.isfinite(raw_temp) else None
-        raw_target = self._safe_float(attrs.get("temperature"))
-        self.target_temperature = raw_target if raw_target is not None and math.isfinite(raw_target) else None
-        self.fan_modes = attrs.get("fan_modes") or []
-        self.swing_modes = attrs.get("swing_modes") or []
-        self.hvac_modes = attrs.get("hvac_modes") or []
-        self.fan_mode = attrs.get("fan_mode")
-        self.swing_mode = attrs.get("swing_mode")
+        self._apply_attr_specs(attrs)
+
+        # Derive on/off state and hvac_mode from top-level state string
+        self.current_state = ha_state.get("state", "off") != "off"
         self.hvac_mode = ha_state.get("state")
-        self.min_temp = self._safe_float(attrs.get("min_temp")) or 16.0
-        self.max_temp = self._safe_float(attrs.get("max_temp")) or 32.0
-        target_humidity = attrs.get("target_humidity")
-        if target_humidity is not None:
-            try:
-                self._target_humidity = int(target_humidity)
-            except (TypeError, ValueError):
-                self._target_humidity = None
-        else:
-            self._target_humidity = None
-        self._preset_mode = attrs.get("preset_mode")
-        self._preset_modes = attrs.get("preset_modes", [])
-        child_lock = attrs.get("child_lock")
-        self._child_lock = bool(child_lock) if child_lock is not None else None
 
     def create_features_list(self) -> list[str]:
         """Return Sber feature list based on available climate capabilities.

--- a/custom_components/sber_mqtt_bridge/devices/climate.py
+++ b/custom_components/sber_mqtt_bridge/devices/climate.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 
 from ..sber_constants import SberFeature
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import ROLE_TEMPERATURE, BaseEntity
+from .base_entity import ROLE_TEMPERATURE, BaseEntity, CommandResult
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -335,7 +335,7 @@ class ClimateEntity(BaseEntity):
             states.append(make_state(SberFeature.CHILD_LOCK, make_bool_value(self._child_lock)))
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber climate commands and produce HA service calls.
 
         Uses a command handler dispatch table (``_cmd_handlers``) to route

--- a/custom_components/sber_mqtt_bridge/devices/curtain.py
+++ b/custom_components/sber_mqtt_bridge/devices/curtain.py
@@ -12,6 +12,7 @@ from .base_entity import (
     SENSOR_LINK_ROLES,
     AttrSpec,
     BaseEntity,
+    CommandResult,
     _safe_int_parser,
 )
 from .utils.signal import rssi_to_signal_strength
@@ -154,7 +155,7 @@ class CurtainEntity(BaseEntity):
     }
     """Map Sber ``open_set`` enum values to HA cover services."""
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber curtain commands and produce HA service calls.
 
         Handles the following Sber keys:

--- a/custom_components/sber_mqtt_bridge/devices/humidifier.py
+++ b/custom_components/sber_mqtt_bridge/devices/humidifier.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import contextlib
 import logging
+from typing import ClassVar
 
 from ..sber_constants import SberFeature
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import ROLE_HUMIDITY, BaseEntity, CommandResult
+from .base_entity import ROLE_HUMIDITY, AttrSpec, BaseEntity, CommandResult, _safe_bool_parser, _safe_int_parser
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +31,18 @@ HA_TO_SBER_HUMIDIFIER_MODE: dict[str, str] = {
 """Map HA humidifier modes to Sber-standard enum values (case-insensitive lookup)."""
 
 
+def _min_humidity_parser(value: object) -> int:
+    """Parse min_humidity, defaulting to 35 on None or invalid."""
+    parsed = _safe_int_parser(value)
+    return parsed or 35
+
+
+def _max_humidity_parser(value: object) -> int:
+    """Parse max_humidity, defaulting to 85 on None or invalid."""
+    parsed = _safe_int_parser(value)
+    return parsed or 85
+
+
 class HumidifierEntity(BaseEntity):
     """Sber humidifier entity for humidity control devices.
 
@@ -41,6 +54,54 @@ class HumidifierEntity(BaseEntity):
     """
 
     LINKABLE_ROLES = (ROLE_HUMIDITY,)
+
+    ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = (
+        AttrSpec(
+            field="target_humidity",
+            attr_keys=("humidity",),
+        ),
+        AttrSpec(
+            field="current_humidity",
+            attr_keys=("current_humidity",),
+            preserve_on_missing=True,
+        ),
+        AttrSpec(
+            field="available_modes",
+            converter=lambda attrs: attrs.get("available_modes") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="mode",
+            attr_keys=("mode",),
+        ),
+        AttrSpec(
+            field="_min_humidity",
+            attr_keys=("min_humidity",),
+            parser=_min_humidity_parser,
+            default=35,
+        ),
+        AttrSpec(
+            field="_max_humidity",
+            attr_keys=("max_humidity",),
+            parser=_max_humidity_parser,
+            default=85,
+        ),
+        AttrSpec(
+            field="_water_level",
+            attr_keys=("water_level",),
+            parser=_safe_int_parser,
+        ),
+        AttrSpec(
+            field="_water_low_level",
+            attr_keys=("water_low_level",),
+            parser=_safe_bool_parser,
+        ),
+        AttrSpec(
+            field="_child_lock",
+            attr_keys=("child_lock",),
+            parser=_safe_bool_parser,
+        ),
+    )
 
     def __init__(self, entity_data: dict) -> None:
         """Initialize humidifier entity.
@@ -69,26 +130,9 @@ class HumidifierEntity(BaseEntity):
                 available_modes, and mode.
         """
         super().fill_by_ha_state(ha_state)
-        self.current_state = ha_state.get("state") == "on"
         attrs = ha_state.get("attributes", {})
-        self.target_humidity = attrs.get("humidity")
-        self.current_humidity = attrs.get("current_humidity")
-        self.available_modes = attrs.get("available_modes") or []
-        self.mode = attrs.get("mode")
-        self._min_humidity = self._safe_int(attrs.get("min_humidity")) or 35
-        self._max_humidity = self._safe_int(attrs.get("max_humidity")) or 85
-        water_level = attrs.get("water_level")
-        if water_level is not None:
-            self._water_level = self._safe_int(water_level)
-        else:
-            self._water_level = None
-        water_low = attrs.get("water_low_level")
-        if water_low is not None:
-            self._water_low_level = bool(water_low)
-        else:
-            self._water_low_level = None
-        child_lock = attrs.get("child_lock")
-        self._child_lock = bool(child_lock) if child_lock is not None else None
+        self._apply_attr_specs(attrs)
+        self.current_state = ha_state.get("state") == "on"
 
     def update_linked_data(self, role: str, ha_state: dict) -> None:
         """Inject current humidity from a linked sensor entity.

--- a/custom_components/sber_mqtt_bridge/devices/humidifier.py
+++ b/custom_components/sber_mqtt_bridge/devices/humidifier.py
@@ -7,7 +7,7 @@ import logging
 
 from ..sber_constants import SberFeature
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import ROLE_HUMIDITY, BaseEntity
+from .base_entity import ROLE_HUMIDITY, BaseEntity, CommandResult
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -195,7 +195,7 @@ class HumidifierEntity(BaseEntity):
             states.append(make_state(SberFeature.CHILD_LOCK, make_bool_value(self._child_lock)))
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber humidifier commands and produce HA service calls.
 
         State is NOT mutated here -- it will be updated when HA fires a

--- a/custom_components/sber_mqtt_bridge/devices/hvac_air_purifier.py
+++ b/custom_components/sber_mqtt_bridge/devices/hvac_air_purifier.py
@@ -7,10 +7,11 @@ read-only features: ionization, night mode, aromatization, filter/ionizer replac
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_enum_value, make_state
-from .base_entity import BaseEntity, CommandResult
+from .base_entity import AttrSpec, BaseEntity, CommandResult, _safe_bool_parser
 from .hvac_fan import _SBER_SPEED_TO_PERCENTAGE, SBER_SPEED_VALUES, _percentage_to_sber_speed
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,6 +30,58 @@ class HvacAirPurifierEntity(BaseEntity):
     - Read-only flags: ionization, night mode, aromatization,
       filter replacement, ionizer replacement, decontamination
     """
+
+    ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = (
+        AttrSpec(
+            field="preset_modes",
+            converter=lambda attrs: attrs.get("preset_modes") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="preset_mode",
+            attr_keys=("preset_mode",),
+        ),
+        AttrSpec(
+            field="percentage",
+            attr_keys=("percentage",),
+        ),
+        AttrSpec(
+            field="_ionization",
+            attr_keys=("ionization",),
+            parser=_safe_bool_parser,
+            default=False,
+        ),
+        AttrSpec(
+            field="_night_mode",
+            attr_keys=("night_mode",),
+            parser=_safe_bool_parser,
+            default=False,
+        ),
+        AttrSpec(
+            field="_aromatization",
+            attr_keys=("aromatization",),
+            parser=_safe_bool_parser,
+            default=False,
+        ),
+        AttrSpec(
+            field="_replace_filter",
+            attr_keys=("replace_filter",),
+            parser=_safe_bool_parser,
+            default=False,
+        ),
+        AttrSpec(
+            field="_replace_ionizator",
+            attr_keys=("replace_ionizator",),
+            parser=_safe_bool_parser,
+            default=False,
+        ),
+        AttrSpec(
+            field="_decontaminate",
+            attr_keys=("decontaminate",),
+            parser=_safe_bool_parser,
+            default=False,
+        ),
+    )
 
     def __init__(self, entity_data: dict) -> None:
         """Initialize air purifier entity.
@@ -55,17 +108,9 @@ class HvacAirPurifierEntity(BaseEntity):
             ha_state: HA state dict with 'state' and 'attributes' keys.
         """
         super().fill_by_ha_state(ha_state)
-        self.current_state = ha_state.get("state") != "off"
         attrs = ha_state.get("attributes", {})
-        self.preset_modes = attrs.get("preset_modes") or []
-        self.preset_mode = attrs.get("preset_mode")
-        self.percentage = attrs.get("percentage")
-        self._ionization = bool(attrs.get("ionization", False))
-        self._night_mode = bool(attrs.get("night_mode", False))
-        self._aromatization = bool(attrs.get("aromatization", False))
-        self._replace_filter = bool(attrs.get("replace_filter", False))
-        self._replace_ionizator = bool(attrs.get("replace_ionizator", False))
-        self._decontaminate = bool(attrs.get("decontaminate", False))
+        self._apply_attr_specs(attrs)
+        self.current_state = ha_state.get("state") != "off"
 
     def _get_sber_speed(self) -> str | None:
         """Get current fan speed as Sber ENUM value.

--- a/custom_components/sber_mqtt_bridge/devices/hvac_air_purifier.py
+++ b/custom_components/sber_mqtt_bridge/devices/hvac_air_purifier.py
@@ -10,7 +10,7 @@ import logging
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_enum_value, make_state
-from .base_entity import BaseEntity
+from .base_entity import BaseEntity, CommandResult
 from .hvac_fan import _SBER_SPEED_TO_PERCENTAGE, SBER_SPEED_VALUES, _percentage_to_sber_speed
 
 _LOGGER = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ class HvacAirPurifierEntity(BaseEntity):
             states.append(make_state(SberFeature.HVAC_DECONTAMINATE, make_bool_value(self._decontaminate)))
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber air purifier commands and produce HA service calls.
 
         Handles the following Sber keys:

--- a/custom_components/sber_mqtt_bridge/devices/hvac_fan.py
+++ b/custom_components/sber_mqtt_bridge/devices/hvac_fan.py
@@ -6,10 +6,11 @@ Supports on/off control and fan speed via the ``hvac_air_flow_power`` feature.
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_enum_value, make_state
-from .base_entity import BaseEntity, CommandResult
+from .base_entity import AttrSpec, BaseEntity, CommandResult
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,6 +63,22 @@ class HvacFanEntity(BaseEntity):
     - Fan speed via preset_mode or percentage-based speed mapping
     """
 
+    ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = (
+        AttrSpec(
+            field="preset_modes",
+            converter=lambda attrs: attrs.get("preset_modes") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="preset_mode",
+            attr_keys=("preset_mode",),
+        ),
+        AttrSpec(
+            field="percentage",
+            attr_keys=("percentage",),
+        ),
+    )
+
     def __init__(self, entity_data: dict) -> None:
         """Initialize fan entity.
 
@@ -81,11 +98,9 @@ class HvacFanEntity(BaseEntity):
             ha_state: HA state dict with 'state' and 'attributes' keys.
         """
         super().fill_by_ha_state(ha_state)
-        self.current_state = ha_state.get("state") != "off"
         attrs = ha_state.get("attributes", {})
-        self.preset_modes = attrs.get("preset_modes") or []
-        self.preset_mode = attrs.get("preset_mode")
-        self.percentage = attrs.get("percentage")
+        self._apply_attr_specs(attrs)
+        self.current_state = ha_state.get("state") != "off"
 
     def _get_sber_speed(self) -> str | None:
         """Get current fan speed as Sber ENUM value.

--- a/custom_components/sber_mqtt_bridge/devices/hvac_fan.py
+++ b/custom_components/sber_mqtt_bridge/devices/hvac_fan.py
@@ -9,7 +9,7 @@ import logging
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_enum_value, make_state
-from .base_entity import BaseEntity
+from .base_entity import BaseEntity, CommandResult
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,7 +154,7 @@ class HvacFanEntity(BaseEntity):
             states.append(make_state(SberFeature.HVAC_AIR_FLOW_POWER, make_enum_value(speed)))
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber fan commands and produce HA service calls.
 
         Handles the following Sber keys:

--- a/custom_components/sber_mqtt_bridge/devices/intercom.py
+++ b/custom_components/sber_mqtt_bridge/devices/intercom.py
@@ -10,6 +10,7 @@ import logging
 
 from ..sber_constants import SberFeature
 from ..sber_models import make_bool_value, make_state
+from .base_entity import CommandResult
 from .on_off_entity import OnOffEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,7 +83,7 @@ class IntercomEntity(OnOffEntity):
         )
         return base
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber intercom commands and produce HA service calls.
 
         Handles ``on_off`` key for turn_on/turn_off. Other features

--- a/custom_components/sber_mqtt_bridge/devices/kettle.py
+++ b/custom_components/sber_mqtt_bridge/devices/kettle.py
@@ -9,7 +9,7 @@ import logging
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_integer_value, make_state
-from .base_entity import BaseEntity
+from .base_entity import BaseEntity, CommandResult
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ class KettleEntity(BaseEntity):
         states.append(make_state(SberFeature.CHILD_LOCK, make_bool_value(self._child_lock)))
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber kettle commands and produce HA service calls.
 
         Handles the following Sber keys:

--- a/custom_components/sber_mqtt_bridge/devices/kettle.py
+++ b/custom_components/sber_mqtt_bridge/devices/kettle.py
@@ -6,15 +6,21 @@ Supports on/off control, water temperature reading, and target temperature setti
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_integer_value, make_state
-from .base_entity import BaseEntity, CommandResult
+from .base_entity import AttrSpec, BaseEntity, CommandResult, _safe_int_parser
 
 _LOGGER = logging.getLogger(__name__)
 
 KETTLE_CATEGORY = "kettle"
 """Sber device category for kettle entities."""
+
+
+def _child_lock_parser(value: object) -> bool:
+    """Parse child_lock attribute, defaulting to False."""
+    return bool(value) if value is not None else False
 
 
 class KettleEntity(BaseEntity):
@@ -27,6 +33,30 @@ class KettleEntity(BaseEntity):
     - Child lock (read-only from HA attributes)
     - Water level and low water level indicators
     """
+
+    ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = (
+        AttrSpec(
+            field="_current_temperature",
+            attr_keys=("current_temperature",),
+            parser=_safe_int_parser,
+        ),
+        AttrSpec(
+            field="_target_temperature",
+            attr_keys=("temperature",),
+            parser=_safe_int_parser,
+        ),
+        AttrSpec(
+            field="_child_lock",
+            attr_keys=("child_lock",),
+            parser=_child_lock_parser,
+            default=False,
+        ),
+        AttrSpec(
+            field="_water_level",
+            attr_keys=("water_level",),
+            parser=_safe_int_parser,
+        ),
+    )
 
     def __init__(self, entity_data: dict) -> None:
         """Initialize kettle entity.
@@ -48,14 +78,10 @@ class KettleEntity(BaseEntity):
             ha_state: HA state dict with 'state' and 'attributes' keys.
         """
         super().fill_by_ha_state(ha_state)
+        attrs = ha_state.get("attributes", {})
+        self._apply_attr_specs(attrs)
         state_str = ha_state.get("state", "")
         self.current_state = state_str not in ("off", "idle", "unavailable", "unknown")
-        attrs = ha_state.get("attributes", {})
-
-        self._current_temperature = self._safe_int(attrs.get("current_temperature"))
-        self._target_temperature = self._safe_int(attrs.get("temperature"))
-        self._child_lock = bool(attrs.get("child_lock", False))
-        self._water_level = self._safe_int(attrs.get("water_level"))
 
     def create_features_list(self) -> list[str]:
         """Return Sber feature list for kettle capabilities.

--- a/custom_components/sber_mqtt_bridge/devices/light.py
+++ b/custom_components/sber_mqtt_bridge/devices/light.py
@@ -17,7 +17,7 @@ from ..sber_models import (
     make_integer_value,
     make_state,
 )
-from .base_entity import BaseEntity
+from .base_entity import SENSOR_LINK_ROLES, BaseEntity
 from .utils.color_converter import ColorConverter
 from .utils.linear_converter import LinearConverter
 
@@ -39,7 +39,12 @@ class LightEntity(BaseEntity):
     - Color temperature (mireds ↔ 0-1000 Sber, reversed)
     - RGB color via HSV conversion
     - Light mode (white / colour)
+
+    Accepts battery / battery_low / signal_strength linked sensors via
+    :attr:`LINKABLE_ROLES` (Zigbee lights commonly report these).
     """
+
+    LINKABLE_ROLES = SENSOR_LINK_ROLES
 
     def __init__(self, ha_entity_data: dict) -> None:
         """Initialize light entity from HA entity data.

--- a/custom_components/sber_mqtt_bridge/devices/light.py
+++ b/custom_components/sber_mqtt_bridge/devices/light.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from typing import ClassVar
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import (
@@ -17,7 +18,7 @@ from ..sber_models import (
     make_integer_value,
     make_state,
 )
-from .base_entity import SENSOR_LINK_ROLES, BaseEntity, CommandResult
+from .base_entity import SENSOR_LINK_ROLES, AttrSpec, BaseEntity, CommandResult, _safe_int_parser
 from .utils.color_converter import ColorConverter
 from .utils.linear_converter import LinearConverter
 
@@ -45,6 +46,42 @@ class LightEntity(BaseEntity):
     """
 
     LINKABLE_ROLES = SENSOR_LINK_ROLES
+
+    ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = (
+        AttrSpec(
+            field="supported_features",
+            attr_keys=("supported_features",),
+            parser=_safe_int_parser,
+            default=0,
+        ),
+        AttrSpec(
+            field="supported_color_modes",
+            converter=lambda attrs: attrs.get("supported_color_modes") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="current_color_mode",
+            attr_keys=("color_mode",),
+        ),
+        AttrSpec(
+            field="_ha_brightness_raw",
+            attr_keys=("brightness",),
+            parser=_safe_int_parser,
+            default=0,
+        ),
+        AttrSpec(
+            field="hs_color",
+            attr_keys=("hs_color",),
+        ),
+        AttrSpec(
+            field="rgb_color",
+            attr_keys=("rgb_color",),
+        ),
+        AttrSpec(
+            field="xy_color",
+            attr_keys=("xy_color",),
+        ),
+    )
 
     def __init__(self, ha_entity_data: dict) -> None:
         """Initialize light entity from HA entity data.
@@ -78,37 +115,35 @@ class LightEntity(BaseEntity):
     def fill_by_ha_state(self, ha_state: dict) -> None:
         """Parse HA state and update all light attributes.
 
+        Simple attribute extraction is handled declaratively via
+        :attr:`ATTR_SPECS`.  Instance-specific LinearConverter transforms
+        and state derivation remain here.
+
         Args:
             ha_state: HA state dict with 'state' and 'attributes' keys.
         """
         super().fill_by_ha_state(ha_state)
         attrs = ha_state.get("attributes", {})
+        self._apply_attr_specs(attrs)
 
+        # Update color_temp converter limits from entity-specific mireds range
         self.max_mireds = attrs.get("max_mireds", 500)
         self.min_mireds = attrs.get("min_mireds", 153)
         if self.max_mireds is not None and self.min_mireds is not None:
             self.color_temp_converter.set_ha_limits(self.min_mireds, self.max_mireds)
 
+        # Derive on/off state from HA state string
         self.current_state = ha_state.get("state", "off") == "on"
-        ha_brightness = attrs.get("brightness", 0)
-        ha_brightness = int(ha_brightness) if ha_brightness is not None else 0
-        self._ha_brightness_raw = ha_brightness
 
-        self.current_sber_brightness = self.brightness_converter.ha_to_sber(ha_brightness)
+        # Apply LinearConverter to raw brightness → Sber scale
+        self.current_sber_brightness = self.brightness_converter.ha_to_sber(self._ha_brightness_raw)
 
+        # Apply LinearConverter to raw color_temp → Sber scale
         ha_color_temp = attrs.get("color_temp", 0)
         if ha_color_temp is not None:
             self.current_sber_color_temp = self.color_temp_converter.ha_to_sber(ha_color_temp)
         else:
             self.current_sber_color_temp = None
-
-        self.current_color_mode = attrs.get("color_mode")
-        self.supported_features = attrs.get("supported_features", 0)
-        self.supported_color_modes = attrs.get("supported_color_modes") or []
-
-        self.hs_color = attrs.get("hs_color")
-        self.rgb_color = attrs.get("rgb_color")
-        self.xy_color = attrs.get("xy_color")
 
     def create_features_list(self) -> list[str]:
         """Return Sber feature list based on available light capabilities.

--- a/custom_components/sber_mqtt_bridge/devices/light.py
+++ b/custom_components/sber_mqtt_bridge/devices/light.py
@@ -17,7 +17,7 @@ from ..sber_models import (
     make_integer_value,
     make_state,
 )
-from .base_entity import SENSOR_LINK_ROLES, BaseEntity
+from .base_entity import SENSOR_LINK_ROLES, BaseEntity, CommandResult
 from .utils.color_converter import ColorConverter
 from .utils.linear_converter import LinearConverter
 
@@ -227,7 +227,7 @@ class LightEntity(BaseEntity):
 
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber light commands and produce HA service calls.
 
         Uses a command handler dispatch table (``_cmd_handlers``) instead

--- a/custom_components/sber_mqtt_bridge/devices/relay.py
+++ b/custom_components/sber_mqtt_bridge/devices/relay.py
@@ -11,6 +11,7 @@ from ..sber_constants import (
     SberFeature,
     SberValueType,
 )
+from .base_entity import CommandResult
 from .on_off_entity import OnOffEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ class RelayEntity(OnOffEntity):
         """
         super().__init__(category, entity_data)
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber on/off command and produce HA service calls.
 
         Handles the ``on_off`` key to generate ``turn_on``/``turn_off`` (or

--- a/custom_components/sber_mqtt_bridge/devices/scenario_button.py
+++ b/custom_components/sber_mqtt_bridge/devices/scenario_button.py
@@ -6,7 +6,7 @@ import logging
 
 from ..sber_constants import SberFeature
 from ..sber_models import make_bool_value, make_enum_value, make_state
-from .base_entity import BaseEntity
+from .base_entity import BaseEntity, CommandResult
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class ScenarioButtonEntity(BaseEntity):
         ]
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber command (no-op for scenario button).
 
         Args:

--- a/custom_components/sber_mqtt_bridge/devices/simple_sensor.py
+++ b/custom_components/sber_mqtt_bridge/devices/simple_sensor.py
@@ -18,7 +18,7 @@ from typing import ClassVar
 
 from ..sber_constants import SberFeature
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import SENSOR_LINK_ROLES, AttrSpec, BaseEntity, _safe_int_parser
+from .base_entity import SENSOR_LINK_ROLES, AttrSpec, BaseEntity, CommandResult, _safe_int_parser
 from .utils.signal import rssi_to_signal_strength
 
 _LOGGER = logging.getLogger(__name__)
@@ -215,7 +215,7 @@ class SimpleReadOnlySensor(BaseEntity):
             states.append(make_state(SberFeature.SENSOR_SENSITIVE, make_enum_value(self._sensor_sensitive)))
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber command (no-op for read-only sensor).
 
         Args:

--- a/custom_components/sber_mqtt_bridge/devices/tv.py
+++ b/custom_components/sber_mqtt_bridge/devices/tv.py
@@ -7,10 +7,11 @@ navigation direction, and custom key commands.
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import BaseEntity, CommandResult
+from .base_entity import AttrSpec, BaseEntity, CommandResult, _safe_bool_parser
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,6 +56,21 @@ _DIRECTION_SERVICE: dict[str, str] = {
 """Sber ``direction`` ENUM to HA media_player service."""
 
 
+def _volume_converter(attrs: dict) -> int:
+    """Convert HA volume_level (0.0-1.0 float) to Sber integer (0-100).
+
+    Args:
+        attrs: HA attributes dict.
+
+    Returns:
+        Integer volume 0-100, or 0 if missing/invalid.
+    """
+    raw = attrs.get("volume_level")
+    if raw is None:
+        return 0
+    return int(float(raw) * 100)
+
+
 class TvEntity(BaseEntity):
     """Sber TV entity for television and media player devices.
 
@@ -66,6 +82,33 @@ class TvEntity(BaseEntity):
     - Channel switching (+/-)
     - Navigation direction (up/down/left/right/ok)
     """
+
+    ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = (
+        AttrSpec(
+            field="_volume",
+            converter=_volume_converter,
+            default=0,
+        ),
+        AttrSpec(
+            field="_is_muted",
+            attr_keys=("is_volume_muted",),
+            parser=_safe_bool_parser,
+            default=False,
+        ),
+        AttrSpec(
+            field="_source",
+            attr_keys=("source",),
+        ),
+        AttrSpec(
+            field="_source_list",
+            converter=lambda attrs: attrs.get("source_list") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="_media_content_id",
+            attr_keys=("media_content_id",),
+        ),
+    )
 
     def __init__(self, entity_data: dict) -> None:
         """Initialize TV entity.
@@ -88,14 +131,9 @@ class TvEntity(BaseEntity):
             ha_state: HA state dict with 'state' and 'attributes' keys.
         """
         super().fill_by_ha_state(ha_state)
-        self.current_state = ha_state.get("state") not in ("off", "standby", "unavailable", "unknown")
         attrs = ha_state.get("attributes", {})
-        vol = self._safe_float(attrs.get("volume_level"))
-        self._volume = int(vol * 100) if vol is not None else 0
-        self._is_muted = bool(attrs.get("is_volume_muted", False))
-        self._source = attrs.get("source")
-        self._source_list = attrs.get("source_list") or []
-        self._media_content_id = attrs.get("media_content_id")
+        self._apply_attr_specs(attrs)
+        self.current_state = ha_state.get("state") not in ("off", "standby", "unavailable", "unknown")
 
     def _has_instance_allowed_values(self) -> bool:
         """TV source_list varies per device — model_id must be unique."""

--- a/custom_components/sber_mqtt_bridge/devices/tv.py
+++ b/custom_components/sber_mqtt_bridge/devices/tv.py
@@ -10,7 +10,7 @@ import logging
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import BaseEntity
+from .base_entity import BaseEntity, CommandResult
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,7 +148,7 @@ class TvEntity(BaseEntity):
             states.append(make_state(SberFeature.SOURCE, make_enum_value(self._source)))
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber TV commands and produce HA service calls.
 
         Handles the following Sber keys:

--- a/custom_components/sber_mqtt_bridge/devices/vacuum_cleaner.py
+++ b/custom_components/sber_mqtt_bridge/devices/vacuum_cleaner.py
@@ -10,7 +10,7 @@ import logging
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import BaseEntity
+from .base_entity import BaseEntity, CommandResult
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ class VacuumCleanerEntity(BaseEntity):
             states.append(make_state(SberFeature.BATTERY_PERCENTAGE, make_integer_value(self._battery_level)))
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber vacuum commands and produce HA service calls.
 
         Handles the following Sber keys:

--- a/custom_components/sber_mqtt_bridge/devices/vacuum_cleaner.py
+++ b/custom_components/sber_mqtt_bridge/devices/vacuum_cleaner.py
@@ -7,10 +7,11 @@ cleaning program (fan speed), and battery level.
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 
 from ..sber_constants import SberFeature, SberValueType
 from ..sber_models import make_bool_value, make_enum_value, make_integer_value, make_state
-from .base_entity import BaseEntity, CommandResult
+from .base_entity import AttrSpec, BaseEntity, CommandResult, _safe_int_parser
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +50,27 @@ class VacuumCleanerEntity(BaseEntity):
     - Battery percentage
     """
 
+    ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = (
+        AttrSpec(
+            field="_fan_speed",
+            attr_keys=("fan_speed",),
+        ),
+        AttrSpec(
+            field="_fan_speed_list",
+            converter=lambda attrs: attrs.get("fan_speed_list") or [],
+            default=[],
+        ),
+        AttrSpec(
+            field="_battery_level",
+            attr_keys=("battery_level",),
+            parser=_safe_int_parser,
+        ),
+        AttrSpec(
+            field="_cleaning_type",
+            attr_keys=("cleaning_type",),
+        ),
+    )
+
     def __init__(self, entity_data: dict) -> None:
         """Initialize vacuum cleaner entity.
 
@@ -69,14 +91,10 @@ class VacuumCleanerEntity(BaseEntity):
             ha_state: HA state dict with 'state' and 'attributes' keys.
         """
         super().fill_by_ha_state(ha_state)
+        attrs = ha_state.get("attributes", {})
+        self._apply_attr_specs(attrs)
         ha_status = ha_state.get("state", "")
         self._status = _HA_STATE_TO_SBER_STATUS.get(ha_status, "standby")
-        attrs = ha_state.get("attributes", {})
-        self._fan_speed = attrs.get("fan_speed")
-        self._fan_speed_list = attrs.get("fan_speed_list") or []
-        self._battery_level = self._safe_int(attrs.get("battery_level"))
-        # cleaning_type from custom attribute (dry/wet/dry_and_wet)
-        self._cleaning_type = attrs.get("cleaning_type")
 
     def create_features_list(self) -> list[str]:
         """Return Sber feature list for vacuum capabilities.

--- a/custom_components/sber_mqtt_bridge/devices/valve.py
+++ b/custom_components/sber_mqtt_bridge/devices/valve.py
@@ -17,6 +17,7 @@ from .base_entity import (
     SENSOR_LINK_ROLES,
     AttrSpec,
     BaseEntity,
+    CommandResult,
     _safe_int_parser,
 )
 from .utils.signal import rssi_to_signal_strength
@@ -148,7 +149,7 @@ class ValveEntity(BaseEntity):
             )
         return {self.entity_id: {"states": states}}
 
-    def process_cmd(self, cmd_data: dict) -> list[dict]:
+    def process_cmd(self, cmd_data: dict) -> list[CommandResult]:
         """Process Sber open_set command and produce HA valve service calls.
 
         Maps ``open_set`` ENUM values:

--- a/custom_components/sber_mqtt_bridge/manifest.json
+++ b/custom_components/sber_mqtt_bridge/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dzerik/sber-mqtt-bridge/issues",
   "loggers": ["aiomqtt"],
   "requirements": ["aiomqtt>=2.0,<3.0", "pydantic>=2.0,<3.0"],
-  "version": "1.26.1"
+  "version": "1.27.0"
 }

--- a/custom_components/sber_mqtt_bridge/reconnect_ack_guard.py
+++ b/custom_components/sber_mqtt_bridge/reconnect_ack_guard.py
@@ -1,0 +1,101 @@
+"""Post-reconnect acknowledgment guard for Sber MQTT Bridge.
+
+After (re)connecting to Sber MQTT, the bridge publishes its device
+config and current states.  Sber cloud may send "corrective" commands
+based on its stale cache before acknowledging our published states.
+Accepting those would override the real HA device state.
+
+This guard blocks command processing until Sber sends a
+``status_request`` or ``config_request`` — an implicit acknowledgment
+that our published state is authoritative.  A fallback timer ensures
+we don't block forever.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ReconnectAckGuard:
+    """Manages post-reconnect acknowledgment guard state.
+
+    Activated after (re)connect, cleared when Sber acknowledges via
+    ``status_request`` / ``config_request``, or when the fallback
+    timer expires.
+
+    Attributes:
+        _awaiting: True while waiting for Sber acknowledgment.
+        _deadline: ``time.monotonic()`` timestamp for fallback timeout.
+        _timeout_handle: Handle for the scheduled fallback timer
+            (``loop.call_later``), so it can be cancelled on cleanup.
+    """
+
+    __slots__ = ("_awaiting", "_deadline", "_timeout_handle")
+
+    def __init__(self) -> None:
+        """Initialize the guard (inactive)."""
+        self._awaiting: bool = False
+        self._deadline: float = 0.0
+        self._timeout_handle: object | None = None
+
+    @property
+    def is_awaiting(self) -> bool:
+        """Return True if still waiting for Sber acknowledgment."""
+        return self._awaiting
+
+    @property
+    def is_deadline_exceeded(self) -> bool:
+        """Return True if the fallback timeout has been reached."""
+        return self._awaiting and time.monotonic() >= self._deadline
+
+    def activate(self, grace_timeout: float, loop: object) -> None:
+        """Activate the guard with a fallback timeout.
+
+        Args:
+            grace_timeout: Seconds to wait before auto-clearing.
+            loop: asyncio event loop for scheduling the timer callback.
+        """
+        self._awaiting = True
+        self._deadline = time.monotonic() + grace_timeout
+        self._timeout_handle = loop.call_later(grace_timeout, self._on_timeout)
+
+    def acknowledge(self) -> None:
+        """Clear the guard (Sber acknowledged our state)."""
+        if self._awaiting:
+            _LOGGER.info("Sber acknowledged — accepting commands")
+            self._awaiting = False
+            self._cancel_timer()
+
+    def clear(self) -> None:
+        """Force-clear the guard (e.g. on disconnect)."""
+        self._awaiting = False
+        self._cancel_timer()
+
+    def timeout_check(self) -> bool:
+        """Check and clear the guard if deadline exceeded.
+
+        Returns:
+            True if the guard was cleared (timed out), False if still active.
+        """
+        if self.is_deadline_exceeded:
+            _LOGGER.info("Sber ack timeout reached — accepting commands")
+            self._awaiting = False
+            return True
+        return False
+
+    def _on_timeout(self) -> None:
+        """Fallback timer callback: auto-clear after grace period."""
+        if self._awaiting:
+            _LOGGER.info("Sber ack timeout reached (timer) — accepting commands")
+            self._awaiting = False
+
+    def _cancel_timer(self) -> None:
+        """Cancel the pending fallback timer if any."""
+        handle = self._timeout_handle
+        if handle is not None:
+            if hasattr(handle, "cancel"):
+                handle.cancel()
+            self._timeout_handle = None

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -211,11 +211,9 @@ class SberBridge:
 
         # Reconnect guard: reject Sber commands until Sber acknowledges
         # our published states (via status_request or config_request).
-        # This prevents Sber cloud from overriding HA state with stale cache.
-        self._awaiting_sber_ack: bool = False
-        """True while waiting for Sber to acknowledge our states after (re)connect."""
-        self._awaiting_sber_ack_deadline: float = 0.0
-        """Fallback deadline: stop waiting even without acknowledgment."""
+        from .reconnect_ack_guard import ReconnectAckGuard
+
+        self._ack_guard = ReconnectAckGuard()
 
         # Delayed confirm tasks per entity (dedup: cancel previous on new command)
         self._confirm_tasks: dict[str, asyncio.Task] = {}
@@ -249,7 +247,7 @@ class SberBridge:
             return "starting"
         if not self._connected:
             return "connecting"
-        if self._awaiting_sber_ack:
+        if self._ack_guard.is_awaiting:
             return "awaiting_ack"
         return "ready"
 
@@ -672,21 +670,10 @@ class SberBridge:
     def _setup_ack_guard(self) -> None:
         """Activate the reconnect-ack guard with a fallback timeout.
 
-        Rejects Sber commands until Sber acknowledges our published states
-        (via status_request / config_request).  Sber cloud may send
-        "corrective" commands based on stale cache — accepting them would
-        override the real HA device state.  The fallback timer ensures we
-        don't block forever even if Sber never sends a message.
+        Delegates to :class:`ReconnectAckGuard` which manages the flag,
+        deadline, and fallback timer.
         """
-        self._awaiting_sber_ack = True
-        self._awaiting_sber_ack_deadline = time.monotonic() + RECONNECT_GRACE_TIMEOUT
-        self._hass.loop.call_later(RECONNECT_GRACE_TIMEOUT, self._ack_timeout_cb)
-
-    def _ack_timeout_cb(self) -> None:
-        """Fallback timer: auto-clear ack flag after grace period."""
-        if self._awaiting_sber_ack:
-            _LOGGER.info("Sber ack timeout reached (timer) — accepting commands")
-            self._awaiting_sber_ack = False
+        self._ack_guard.activate(RECONNECT_GRACE_TIMEOUT, self._hass.loop)
 
     async def _handle_disconnect(self, err: Exception, *, unexpected: bool = False) -> bool:
         """Handle MQTT disconnection: reset state, log, backoff, check repairs.
@@ -895,8 +882,7 @@ class SberBridge:
         # may become None between the connectivity check and the ``publish``
         # call if the transport drops mid-await.  The local reference is
         # stable even if the attribute is cleared concurrently.
-        client = self._mqtt_client
-        if not self._connected or client is None:
+        if not self._connected or self._mqtt_service is None:
             return
 
         # Value change diffing: skip entities whose Sber state has not changed
@@ -912,8 +898,8 @@ class SberBridge:
         payload, payload_valid = build_states_list_json(self._entities, entity_ids, self._enabled_entity_ids)
         topic = f"{self._root_topic}/up/status"
         try:
-            await client.publish(topic, payload)
-        except aiomqtt.MqttError:
+            await self._mqtt_service.publish(topic, payload)
+        except (aiomqtt.MqttError, RuntimeError):
             self._stats.publish_errors += 1
             _LOGGER.exception("Error publishing states to Sber")
             return
@@ -931,8 +917,7 @@ class SberBridge:
 
     async def _publish_config(self, entity_ids: list[str] | None = None) -> None:
         """Publish device config to Sber MQTT."""
-        client = self._mqtt_client
-        if not self._connected or client is None:
+        if not self._connected or self._mqtt_service is None:
             return
 
         ids_to_publish = entity_ids or self._enabled_entity_ids
@@ -951,8 +936,8 @@ class SberBridge:
         )
         topic = f"{self._root_topic}/up/config"
         try:
-            await client.publish(topic, payload)
-        except aiomqtt.MqttError:
+            await self._mqtt_service.publish(topic, payload)
+        except (aiomqtt.MqttError, RuntimeError):
             self._stats.publish_errors += 1
             _LOGGER.exception("Error publishing config to Sber")
             return

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -24,6 +24,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 
 from .command_dispatcher import SberCommandDispatcher
 from .const import (
+    CONF_CONFIRM_DELAY,
     CONF_DEBOUNCE_DELAY,
     CONF_HUB_AUTO_PARENT,
     CONF_MAX_MQTT_PAYLOAD,
@@ -388,6 +389,7 @@ class SberBridge:
         self._debounce_delay: float = float(options.get(CONF_DEBOUNCE_DELAY, SETTINGS_DEFAULTS[CONF_DEBOUNCE_DELAY]))
         self._max_payload_size: int = int(options.get(CONF_MAX_MQTT_PAYLOAD, SETTINGS_DEFAULTS[CONF_MAX_MQTT_PAYLOAD]))
         self._message_log_size: int = int(options.get(CONF_MESSAGE_LOG_SIZE, SETTINGS_DEFAULTS[CONF_MESSAGE_LOG_SIZE]))
+        self._confirm_delay: float = float(options.get(CONF_CONFIRM_DELAY, SETTINGS_DEFAULTS[CONF_CONFIRM_DELAY]))
         # verify_ssl has a special path: config_entry.data fallback for migrated entries
         self._verify_ssl: bool = bool(
             options.get(
@@ -780,15 +782,15 @@ class SberBridge:
     async def _delayed_confirm(self, entity_id: str) -> None:
         """Delayed state confirmation for a commanded entity.
 
-        Waits 1.5 seconds (letting HA settle async attribute updates) and
-        then re-publishes the entity's current state to Sber.  Cleans up
-        ``_confirm_tasks`` entry on completion.
+        Waits :attr:`_confirm_delay` seconds (letting HA settle async
+        attribute updates) and then re-publishes the entity's current
+        state to Sber.  Cleans up ``_confirm_tasks`` entry on completion.
 
         Args:
             entity_id: HA entity identifier to confirm.
         """
         try:
-            await asyncio.sleep(1.5)
+            await asyncio.sleep(self._confirm_delay)
             entity = self._entities.get(entity_id)
             if entity is not None:
                 ha_state = self._hass.states.get(entity_id)

--- a/custom_components/sber_mqtt_bridge/sber_protocol.py
+++ b/custom_components/sber_mqtt_bridge/sber_protocol.py
@@ -15,7 +15,7 @@ from .sber_models import validate_config_payload, validate_status_payload
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = "1.26.1"
+VERSION = "1.27.0"
 """Protocol version string included in the hub device descriptor."""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sber-mqtt-bridge"
-version = "1.26.1"
+version = "1.27.0"
 description = "Sber Smart Home MQTT Bridge for Home Assistant"
 requires-python = ">=3.13"
 license = "MIT"

--- a/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
+++ b/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.26.1',
+        'hw_version': '1.27.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.26.1',
+        'sw_version': '1.27.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.26.1',
+        'hw_version': '1.27.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.26.1',
+        'sw_version': '1.27.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/snapshots/test_protocol_snapshots.ambr
+++ b/tests/hacs/snapshots/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.26.1',
+        'hw_version': '1.27.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.26.1',
+        'sw_version': '1.27.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.26.1',
+        'hw_version': '1.27.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.26.1',
+        'sw_version': '1.27.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/test_bridge.py
+++ b/tests/hacs/test_bridge.py
@@ -69,47 +69,36 @@ class TestSberBridgeMessageRouting:
 
     @pytest.mark.asyncio
     async def test_route_commands(self, bridge):
-        await bridge._handle_mqtt_message(
-            "sberdevices/v1/test/down/commands", b'{"devices": {}}'
-        )
+        await bridge._handle_mqtt_message("sberdevices/v1/test/down/commands", b'{"devices": {}}')
         bridge._handle_sber_command.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_route_status_request(self, bridge):
-        await bridge._handle_mqtt_message(
-            "sberdevices/v1/test/down/status_request", b'{"devices": []}'
-        )
+        await bridge._handle_mqtt_message("sberdevices/v1/test/down/status_request", b'{"devices": []}')
         bridge._handle_sber_status_request.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_route_config_request(self, bridge):
-        await bridge._handle_mqtt_message(
-            "sberdevices/v1/test/down/config_request", b''
-        )
+        await bridge._handle_mqtt_message("sberdevices/v1/test/down/config_request", b"")
         bridge._handle_sber_config_request.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_route_change_group(self, bridge):
         await bridge._handle_mqtt_message(
-            "sberdevices/v1/test/down/change_group_device_request",
-            b'{"device_id": "light.a"}'
+            "sberdevices/v1/test/down/change_group_device_request", b'{"device_id": "light.a"}'
         )
         bridge._handle_change_group.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_route_rename(self, bridge):
         await bridge._handle_mqtt_message(
-            "sberdevices/v1/test/down/rename_device_request",
-            b'{"device_id": "light.a", "new_name": "New"}'
+            "sberdevices/v1/test/down/rename_device_request", b'{"device_id": "light.a", "new_name": "New"}'
         )
         bridge._handle_rename_device.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_route_global_config(self, bridge):
-        await bridge._handle_mqtt_message(
-            "sberdevices/v1/__config",
-            b'{"http_api_endpoint": "https://test"}'
-        )
+        await bridge._handle_mqtt_message("sberdevices/v1/__config", b'{"http_api_endpoint": "https://test"}')
         bridge._handle_global_config.assert_called_once()
 
 
@@ -133,13 +122,9 @@ class TestSberBridgeCommandHandling:
         entity.fill_by_ha_state({"entity_id": "switch.lamp", "state": "off", "attributes": {}})
         bridge._entities["switch.lamp"] = entity
 
-        payload = json.dumps({
-            "devices": {
-                "switch.lamp": {
-                    "states": [{"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}]
-                }
-            }
-        })
+        payload = json.dumps(
+            {"devices": {"switch.lamp": {"states": [{"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}]}}}
+        )
 
         await bridge._handle_sber_command(payload.encode())
 
@@ -154,9 +139,7 @@ class TestSberBridgeCommandHandling:
 
     @pytest.mark.asyncio
     async def test_handle_command_unknown_entity(self, bridge):
-        payload = json.dumps({
-            "devices": {"unknown.entity": {"states": []}}
-        })
+        payload = json.dumps({"devices": {"unknown.entity": {"states": []}}})
         await bridge._handle_sber_command(payload.encode())
         bridge._hass.services.async_call.assert_not_called()
 
@@ -174,11 +157,13 @@ class TestSberBridgeRedefinitions:
 
     @pytest.mark.asyncio
     async def test_change_group(self, bridge):
-        payload = json.dumps({
-            "device_id": "light.room",
-            "home": "My House",
-            "room": "Bedroom",
-        })
+        payload = json.dumps(
+            {
+                "device_id": "light.room",
+                "home": "My House",
+                "room": "Bedroom",
+            }
+        )
         await bridge._handle_change_group(payload.encode())
 
         assert bridge._redefinitions["light.room"]["home"] == "My House"
@@ -188,10 +173,12 @@ class TestSberBridgeRedefinitions:
 
     @pytest.mark.asyncio
     async def test_rename_device(self, bridge):
-        payload = json.dumps({
-            "device_id": "switch.lamp",
-            "new_name": "Night Lamp",
-        })
+        payload = json.dumps(
+            {
+                "device_id": "switch.lamp",
+                "new_name": "Night Lamp",
+            }
+        )
         await bridge._handle_rename_device(payload.encode())
 
         assert bridge._redefinitions["switch.lamp"]["name"] == "Night Lamp"
@@ -220,6 +207,7 @@ class TestSberBridgePublish:
         entry = _make_entry()
         b = SberBridge(hass, entry)
         b._mqtt_client = AsyncMock()
+        b._mqtt_service.publish = AsyncMock()
         b._connected = True
         return b
 
@@ -234,15 +222,15 @@ class TestSberBridgePublish:
 
         await bridge._publish_states(["switch.lamp"])
 
-        bridge._mqtt_client.publish.assert_called_once()
-        call_args = bridge._mqtt_client.publish.call_args
+        bridge._mqtt_service.publish.assert_called_once()
+        call_args = bridge._mqtt_service.publish.call_args
         assert "up/status" in call_args[0][0]
 
     @pytest.mark.asyncio
     async def test_publish_skips_when_disconnected(self, bridge):
         bridge._connected = False
         await bridge._publish_states(["switch.lamp"])
-        bridge._mqtt_client.publish.assert_not_called()
+        bridge._mqtt_service.publish.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_publish_config(self, bridge):
@@ -255,8 +243,8 @@ class TestSberBridgePublish:
 
         await bridge._publish_config()
 
-        bridge._mqtt_client.publish.assert_called_once()
-        call_args = bridge._mqtt_client.publish.call_args
+        bridge._mqtt_service.publish.assert_called_once()
+        call_args = bridge._mqtt_service.publish.call_args
         assert "up/config" in call_args[0][0]
         payload = json.loads(call_args[0][1])
         assert len(payload["devices"]) == 2  # hub + lamp
@@ -286,9 +274,7 @@ class TestSberBridgeEchoFix:
         b._connected = True
 
         entity = RelayEntity({"entity_id": "switch.lamp", "name": "Lamp"})
-        entity.fill_by_ha_state(
-            {"entity_id": "switch.lamp", "state": "off", "attributes": {}}
-        )
+        entity.fill_by_ha_state({"entity_id": "switch.lamp", "state": "off", "attributes": {}})
         b._entities["switch.lamp"] = entity
         b._enabled_entity_ids = ["switch.lamp"]
 
@@ -303,15 +289,9 @@ class TestSberBridgeEchoFix:
         still publish the state confirmation back to Sber.
         """
         # Arrange: send Sber command to turn on the relay
-        payload = json.dumps({
-            "devices": {
-                "switch.lamp": {
-                    "states": [
-                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}
-                    ]
-                }
-            }
-        })
+        payload = json.dumps(
+            {"devices": {"switch.lamp": {"states": [{"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}]}}}
+        )
         await bridge._handle_sber_command(payload.encode())
 
         # Capture the Context that was passed to async_call
@@ -338,9 +318,7 @@ class TestSberBridgeEchoFix:
             "new_state": new_state,
         }
 
-        with patch.object(
-            bridge._state_forwarder, "_schedule_debounced_publish"
-        ) as mock_publish:
+        with patch.object(bridge._state_forwarder, "_schedule_debounced_publish") as mock_publish:
             bridge._on_ha_state_changed(event)
 
             # Assert: publish is NOT suppressed
@@ -366,9 +344,7 @@ class TestSberBridgeEchoFix:
             "new_state": new_state,
         }
 
-        with patch.object(
-            bridge._state_forwarder, "_schedule_debounced_publish"
-        ) as mock_publish:
+        with patch.object(bridge._state_forwarder, "_schedule_debounced_publish") as mock_publish:
             bridge._on_ha_state_changed(event)
 
             mock_publish.assert_called_once_with("switch.lamp")
@@ -376,21 +352,13 @@ class TestSberBridgeEchoFix:
     @pytest.mark.asyncio
     async def test_sber_command_creates_ha_context(self, bridge):
         """Sber command must create an HA Context for logbook attribution."""
-        payload = json.dumps({
-            "devices": {
-                "switch.lamp": {
-                    "states": [
-                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}
-                    ]
-                }
-            }
-        })
+        payload = json.dumps(
+            {"devices": {"switch.lamp": {"states": [{"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}]}}}
+        )
 
         await bridge._handle_sber_command(payload.encode())
 
         bridge._hass.services.async_call.assert_called_once()
         call_kwargs = bridge._hass.services.async_call.call_args
         context_arg = call_kwargs.kwargs.get("context") or call_kwargs[1].get("context")
-        assert isinstance(context_arg, Context), (
-            "async_call must receive a Context instance for HA logbook attribution"
-        )
+        assert isinstance(context_arg, Context), "async_call must receive a Context instance for HA logbook attribution"

--- a/tests/hacs/test_device_grouper.py
+++ b/tests/hacs/test_device_grouper.py
@@ -188,11 +188,11 @@ class TestLightDevices:
         assert group.area == "Living Room"
         assert group.primary.entity_id == "light.living_room_lamp"
         assert group.primary.role == EntityRole.PRIMARY
-        # NOTE: LightEntity.LINKABLE_ROLES = () in current code, so these will
-        # actually end up in unsupported rather than linked_native.  Test
-        # asserts the current (documented in ARCHITECTURE_RESEARCH §1.3) state.
-        assert len(group.linked_native) == 0
-        assert len(group.unsupported) == 2
+        # LightEntity.LINKABLE_ROLES = SENSOR_LINK_ROLES, so battery + signal
+        # are correctly classified as linked_native.
+        assert len(group.linked_native) == 2
+        assert {e.link_role for e in group.linked_native} == {"battery", "signal_strength"}
+        assert len(group.unsupported) == 0
 
     def test_no_light_devices_returns_empty(self, hass, mock_registries):
         entity_reg, device_reg, _ = mock_registries

--- a/tests/hacs/test_integration_flows.py
+++ b/tests/hacs/test_integration_flows.py
@@ -75,16 +75,23 @@ def _make_bridge(hass, entity_cls, entity_id, ha_state, ha_attrs=None, *, cls_kw
     entry = _make_entry()
     bridge = SberBridge(hass, entry)
     bridge._mqtt_client = AsyncMock()
+    bridge._mqtt_service.publish = AsyncMock()
     bridge._connected = True
-    bridge._awaiting_sber_ack = False
+    bridge._ack_guard.clear()
 
     kwargs = cls_kwargs or {}
-    entity = entity_cls({"entity_id": entity_id, "name": "Test"}, **kwargs) if kwargs else entity_cls({"entity_id": entity_id, "name": "Test"})
-    entity.fill_by_ha_state({
-        "entity_id": entity_id,
-        "state": ha_state,
-        "attributes": ha_attrs or {},
-    })
+    entity = (
+        entity_cls({"entity_id": entity_id, "name": "Test"}, **kwargs)
+        if kwargs
+        else entity_cls({"entity_id": entity_id, "name": "Test"})
+    )
+    entity.fill_by_ha_state(
+        {
+            "entity_id": entity_id,
+            "state": ha_state,
+            "attributes": ha_attrs or {},
+        }
+    )
     bridge._entities[entity_id] = entity
     bridge._enabled_entity_ids = [entity_id]
     return bridge
@@ -102,7 +109,7 @@ def _sber_cmd_payload(devices_dict: dict) -> bytes:
 def _get_published_payloads(bridge) -> list[dict]:
     """Extract all published state payloads from the mqtt mock."""
     results = []
-    for c in bridge._mqtt_client.publish.call_args_list:
+    for c in bridge._mqtt_service.publish.call_args_list:
         args = c.args if c.args else c[0]
         topic = args[0]
         if "up/status" in str(topic):
@@ -113,7 +120,7 @@ def _get_published_payloads(bridge) -> list[dict]:
 def _get_published_config_payloads(bridge) -> list[dict]:
     """Extract all published config payloads from the mqtt mock."""
     results = []
-    for c in bridge._mqtt_client.publish.call_args_list:
+    for c in bridge._mqtt_service.publish.call_args_list:
         args = c.args if c.args else c[0]
         topic = args[0]
         if "up/config" in str(topic):
@@ -171,13 +178,15 @@ class TestBridgeFlowBasic:
         ha_state_after = _mock_ha_state("on")
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "switch.lamp": {
-                "states": [
-                    {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "switch.lamp": {
+                    "states": [
+                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -209,13 +218,15 @@ class TestBridgeFlowBasic:
         ha_state_after = _mock_ha_state("off")
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "switch.lamp": {
-                "states": [
-                    {"key": "on_off", "value": {"type": "BOOL", "bool_value": False}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "switch.lamp": {
+                    "states": [
+                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": False}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -256,21 +267,26 @@ class TestBridgeFlowDelayedConfirm:
             },
         )
 
-        ha_state_after = _mock_ha_state("on", {
-            "brightness": 128,
-            "color_mode": "color_temp",
-            "supported_color_modes": ["color_temp", "hs"],
-            "color_temp": 300,
-        })
+        ha_state_after = _mock_ha_state(
+            "on",
+            {
+                "brightness": 128,
+                "color_mode": "color_temp",
+                "supported_color_modes": ["color_temp", "hs"],
+                "color_temp": 300,
+            },
+        )
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "light.lamp": {
-                "states": [
-                    {"key": "light_brightness", "value": {"type": "INTEGER", "integer_value": 500}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "light.lamp": {
+                    "states": [
+                        {"key": "light_brightness", "value": {"type": "INTEGER", "integer_value": 500}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -306,28 +322,33 @@ class TestBridgeFlowDelayedConfirm:
         bridge._entities["light.lamp"].mark_state_published()
 
         # After command, HA now reports color mode as "rgb" with a TUPLE hs_color
-        ha_state_after = _mock_ha_state("on", {
-            "brightness": 255,
-            "color_mode": "rgb",
-            "supported_color_modes": ["color_temp", "hs", "rgb"],
-            "hs_color": (283.0, 100.0),
-            "color_temp": 300,
-        })
+        ha_state_after = _mock_ha_state(
+            "on",
+            {
+                "brightness": 255,
+                "color_mode": "rgb",
+                "supported_color_modes": ["color_temp", "hs", "rgb"],
+                "hs_color": (283.0, 100.0),
+                "color_temp": 300,
+            },
+        )
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "light.lamp": {
-                "states": [
-                    {
-                        "key": "light_colour",
-                        "value": {
-                            "type": "COLOUR",
-                            "colour_value": {"h": 283, "s": 1000, "v": 1000},
+        payload = _sber_cmd_payload(
+            {
+                "light.lamp": {
+                    "states": [
+                        {
+                            "key": "light_colour",
+                            "value": {
+                                "type": "COLOUR",
+                                "colour_value": {"h": 283, "s": 1000, "v": 1000},
+                            },
                         },
-                    },
-                ],
-            },
-        })
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -366,29 +387,34 @@ class TestBridgeFlowDelayedConfirm:
         bridge._entities["light.lamp"].mark_state_published()
 
         # After command, HA reports rgb mode with TUPLE hs_color
-        ha_state_after = _mock_ha_state("on", {
-            "brightness": 255,
-            "color_mode": "rgb",
-            "supported_color_modes": ["color_temp", "hs", "rgb"],
-            "hs_color": (283.0, 100.0),
-            "color_temp": 300,
-        })
+        ha_state_after = _mock_ha_state(
+            "on",
+            {
+                "brightness": 255,
+                "color_mode": "rgb",
+                "supported_color_modes": ["color_temp", "hs", "rgb"],
+                "hs_color": (283.0, 100.0),
+                "color_temp": 300,
+            },
+        )
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "light.lamp": {
-                "states": [
-                    {"key": "light_mode", "value": {"type": "ENUM", "enum_value": "colour"}},
-                    {
-                        "key": "light_colour",
-                        "value": {
-                            "type": "COLOUR",
-                            "colour_value": {"h": 283, "s": 1000, "v": 1000},
+        payload = _sber_cmd_payload(
+            {
+                "light.lamp": {
+                    "states": [
+                        {"key": "light_mode", "value": {"type": "ENUM", "enum_value": "colour"}},
+                        {
+                            "key": "light_colour",
+                            "value": {
+                                "type": "COLOUR",
+                                "colour_value": {"h": 283, "s": 1000, "v": 1000},
+                            },
                         },
-                    },
-                ],
-            },
-        })
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -402,9 +428,7 @@ class TestBridgeFlowDelayedConfirm:
         device_states = payloads[-1]["devices"]["light.lamp"]["states"]
         mode_val = _find_state_value(device_states, "light_mode")
         assert mode_val is not None
-        assert mode_val["enum_value"] == "colour", (
-            "Delayed confirm must publish 'colour' mode, not 'white'"
-        )
+        assert mode_val["enum_value"] == "colour", "Delayed confirm must publish 'colour' mode, not 'white'"
 
 
 # ---------------------------------------------------------------------------
@@ -420,29 +444,33 @@ class TestBridgeFlowDebounce:
         entity = LightEntity({"entity_id": "light.lamp", "name": "Test"})
 
         # First fill: color_temp mode
-        entity.fill_by_ha_state({
-            "entity_id": "light.lamp",
-            "state": "on",
-            "attributes": {
-                "brightness": 255,
-                "color_mode": "color_temp",
-                "supported_color_modes": ["color_temp", "hs"],
-                "color_temp": 300,
-            },
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "light.lamp",
+                "state": "on",
+                "attributes": {
+                    "brightness": 255,
+                    "color_mode": "color_temp",
+                    "supported_color_modes": ["color_temp", "hs"],
+                    "color_temp": 300,
+                },
+            }
+        )
         entity.mark_state_published()
 
         # Second fill: rgb mode, different hs_color
-        entity.fill_by_ha_state({
-            "entity_id": "light.lamp",
-            "state": "on",
-            "attributes": {
-                "brightness": 255,
-                "color_mode": "rgb",
-                "supported_color_modes": ["color_temp", "hs"],
-                "hs_color": (283.0, 100.0),
-            },
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "light.lamp",
+                "state": "on",
+                "attributes": {
+                    "brightness": 255,
+                    "color_mode": "rgb",
+                    "supported_color_modes": ["color_temp", "hs"],
+                    "hs_color": (283.0, 100.0),
+                },
+            }
+        )
 
         assert entity.has_significant_change() is True
 
@@ -466,13 +494,15 @@ class TestBridgeFlowDebounce:
         ):
             for on_val in commands:
                 last_cmd_state["state"] = "on" if on_val else "off"
-                payload = _sber_cmd_payload({
-                    "switch.lamp": {
-                        "states": [
-                            {"key": "on_off", "value": {"type": "BOOL", "bool_value": on_val}},
-                        ],
-                    },
-                })
+                payload = _sber_cmd_payload(
+                    {
+                        "switch.lamp": {
+                            "states": [
+                                {"key": "on_off", "value": {"type": "BOOL", "bool_value": on_val}},
+                            ],
+                        },
+                    }
+                )
                 await bridge._handle_sber_command(payload)
             await _drain_tasks(hass)
 
@@ -502,16 +532,17 @@ class TestBridgeFlowReconnect:
         hass.states.get = MagicMock(return_value=ha_state_after)
 
         # Activate reconnect guard
-        bridge._awaiting_sber_ack = True
-        bridge._awaiting_sber_ack_deadline = time.monotonic() + 30
+        bridge._ack_guard.activate(30, hass.loop)
 
-        payload = _sber_cmd_payload({
-            "switch.lamp": {
-                "states": [
-                    {"key": "on_off", "value": {"type": "BOOL", "bool_value": False}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "switch.lamp": {
+                    "states": [
+                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": False}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -527,9 +558,9 @@ class TestBridgeFlowReconnect:
         assert len(payloads) >= 1
 
         # Clear reconnect guard
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
         hass.services.async_call.reset_mock()
-        bridge._mqtt_client.publish.reset_mock()
+        bridge._mqtt_service.publish.reset_mock()
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -555,13 +586,15 @@ class TestBridgeFlowEdgeCases:
         hass = _make_hass()
         bridge = _make_bridge(hass, RelayEntity, "switch.lamp", "on")
 
-        payload = _sber_cmd_payload({
-            "switch.unknown": {
-                "states": [
-                    {"key": "on_off", "value": {"type": "BOOL", "bool_value": False}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "switch.unknown": {
+                    "states": [
+                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": False}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -579,8 +612,9 @@ class TestBridgeFlowEdgeCases:
         entry = _make_entry()
         bridge = SberBridge(hass, entry)
         bridge._mqtt_client = AsyncMock()
+        bridge._mqtt_service.publish = AsyncMock()
         bridge._connected = True
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
 
         entity_a = RelayEntity({"entity_id": "switch.a", "name": "A"})
         entity_a.fill_by_ha_state({"entity_id": "switch.a", "state": "off", "attributes": {}})
@@ -600,14 +634,16 @@ class TestBridgeFlowEdgeCases:
 
         hass.states.get = MagicMock(side_effect=_states_get)
 
-        payload = _sber_cmd_payload({
-            "switch.a": {
-                "states": [{"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}],
-            },
-            "switch.b": {
-                "states": [{"key": "on_off", "value": {"type": "BOOL", "bool_value": False}}],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "switch.a": {
+                    "states": [{"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}],
+                },
+                "switch.b": {
+                    "states": [{"key": "on_off", "value": {"type": "BOOL", "bool_value": False}}],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -654,22 +690,27 @@ class TestClimateFlows:
             },
         )
 
-        ha_state_after = _mock_ha_state("heat", {
-            "fan_modes": ["auto", "low", "medium", "high"],
-            "hvac_modes": ["off", "cool", "heat", "auto"],
-            "fan_mode": "auto",
-            "temperature": 24,
-            "current_temperature": 22,
-        })
+        ha_state_after = _mock_ha_state(
+            "heat",
+            {
+                "fan_modes": ["auto", "low", "medium", "high"],
+                "hvac_modes": ["off", "cool", "heat", "auto"],
+                "fan_mode": "auto",
+                "temperature": 24,
+                "current_temperature": 22,
+            },
+        )
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "climate.ac": {
-                "states": [
-                    {"key": "hvac_work_mode", "value": {"type": "ENUM", "enum_value": "heating"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "climate.ac": {
+                    "states": [
+                        {"key": "hvac_work_mode", "value": {"type": "ENUM", "enum_value": "heating"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -680,10 +721,7 @@ class TestClimateFlows:
 
         # Verify set_hvac_mode was called
         calls = hass.services.async_call.call_args_list
-        hvac_mode_calls = [
-            c for c in calls
-            if c.kwargs.get("service") == "set_hvac_mode"
-        ]
+        hvac_mode_calls = [c for c in calls if c.kwargs.get("service") == "set_hvac_mode"]
         assert len(hvac_mode_calls) == 1
         assert hvac_mode_calls[0].kwargs["service_data"]["hvac_mode"] == "heat"
 
@@ -708,14 +746,16 @@ class TestClimateFlows:
         ha_state_after = _mock_ha_state("cool", {"temperature": 25})
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "climate.ac": {
-                "states": [
-                    {"key": "hvac_temp_set", "value": {"type": "INTEGER", "integer_value": 25}},
-                    {"key": "hvac_work_mode", "value": {"type": "ENUM", "enum_value": "cooling"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "climate.ac": {
+                    "states": [
+                        {"key": "hvac_temp_set", "value": {"type": "INTEGER", "integer_value": 25}},
+                        {"key": "hvac_work_mode", "value": {"type": "ENUM", "enum_value": "cooling"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -724,9 +764,7 @@ class TestClimateFlows:
             await bridge._handle_sber_command(payload)
             await _drain_tasks(hass)
 
-        services_called = [
-            c.kwargs.get("service") for c in hass.services.async_call.call_args_list
-        ]
+        services_called = [c.kwargs.get("service") for c in hass.services.async_call.call_args_list]
         assert "set_temperature" in services_called
         assert "set_hvac_mode" in services_called
 
@@ -752,13 +790,15 @@ class TestClimateFlows:
         ha_state_after = _mock_ha_state("cool", {"preset_mode": "sleep"})
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "climate.ac": {
-                "states": [
-                    {"key": "hvac_night_mode", "value": {"type": "BOOL", "bool_value": True}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "climate.ac": {
+                    "states": [
+                        {"key": "hvac_night_mode", "value": {"type": "BOOL", "bool_value": True}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -799,14 +839,16 @@ class TestHumidifierFlows:
         ha_state_after = _mock_ha_state("on", {"humidity": 60, "mode": "high"})
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "humidifier.room": {
-                "states": [
-                    {"key": "hvac_humidity_set", "value": {"type": "INTEGER", "integer_value": "60"}},
-                    {"key": "hvac_air_flow_power", "value": {"type": "ENUM", "enum_value": "high"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "humidifier.room": {
+                    "states": [
+                        {"key": "hvac_humidity_set", "value": {"type": "INTEGER", "integer_value": "60"}},
+                        {"key": "hvac_air_flow_power", "value": {"type": "ENUM", "enum_value": "high"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -815,9 +857,7 @@ class TestHumidifierFlows:
             await bridge._handle_sber_command(payload)
             await _drain_tasks(hass)
 
-        services_called = [
-            c.kwargs.get("service") for c in hass.services.async_call.call_args_list
-        ]
+        services_called = [c.kwargs.get("service") for c in hass.services.async_call.call_args_list]
         assert "set_humidity" in services_called
         assert "set_mode" in services_called
 
@@ -844,13 +884,15 @@ class TestCurtainFlows:
         ha_state_after = _mock_ha_state("closed", {"current_position": 0})
         hass.states.get = MagicMock(return_value=ha_state_after)
 
-        payload = _sber_cmd_payload({
-            "cover.blinds": {
-                "states": [
-                    {"key": "open_percentage", "value": {"type": "INTEGER", "integer_value": "0"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "cover.blinds": {
+                    "states": [
+                        {"key": "open_percentage", "value": {"type": "INTEGER", "integer_value": "0"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -888,13 +930,15 @@ class TestCurtainFlows:
         ]
         for enum_val, expected_service in test_cases:
             hass.services.async_call.reset_mock()
-            payload = _sber_cmd_payload({
-                "cover.blinds": {
-                    "states": [
-                        {"key": "open_set", "value": {"type": "ENUM", "enum_value": enum_val}},
-                    ],
-                },
-            })
+            payload = _sber_cmd_payload(
+                {
+                    "cover.blinds": {
+                        "states": [
+                            {"key": "open_set", "value": {"type": "ENUM", "enum_value": enum_val}},
+                        ],
+                    },
+                }
+            )
 
             with patch(
                 "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -904,9 +948,7 @@ class TestCurtainFlows:
 
             calls = hass.services.async_call.call_args_list
             service_calls = [c for c in calls if c.kwargs.get("service") == expected_service]
-            assert len(service_calls) >= 1, (
-                f"Expected {expected_service} for open_set={enum_val}"
-            )
+            assert len(service_calls) >= 1, f"Expected {expected_service} for open_set={enum_val}"
 
 
 # ---------------------------------------------------------------------------
@@ -931,18 +973,18 @@ class TestTvFlows:
                 "source": "TV",
             },
         )
-        hass.states.get = MagicMock(
-            return_value=_mock_ha_state("playing", {"volume_level": 0.3, "source": "HDMI"})
-        )
+        hass.states.get = MagicMock(return_value=_mock_ha_state("playing", {"volume_level": 0.3, "source": "HDMI"}))
 
-        payload = _sber_cmd_payload({
-            "media_player.tv": {
-                "states": [
-                    {"key": "volume_int", "value": {"type": "INTEGER", "integer_value": 30}},
-                    {"key": "source", "value": {"type": "ENUM", "enum_value": "HDMI"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "media_player.tv": {
+                    "states": [
+                        {"key": "volume_int", "value": {"type": "INTEGER", "integer_value": 30}},
+                        {"key": "source", "value": {"type": "ENUM", "enum_value": "HDMI"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -951,17 +993,12 @@ class TestTvFlows:
             await bridge._handle_sber_command(payload)
             await _drain_tasks(hass)
 
-        services_called = [
-            c.kwargs.get("service") for c in hass.services.async_call.call_args_list
-        ]
+        services_called = [c.kwargs.get("service") for c in hass.services.async_call.call_args_list]
         assert "volume_set" in services_called
         assert "select_source" in services_called
 
         # Verify volume level = 30/100 = 0.3
-        vol_calls = [
-            c for c in hass.services.async_call.call_args_list
-            if c.kwargs.get("service") == "volume_set"
-        ]
+        vol_calls = [c for c in hass.services.async_call.call_args_list if c.kwargs.get("service") == "volume_set"]
         assert vol_calls[0].kwargs["service_data"]["volume_level"] == pytest.approx(0.3, abs=0.01)
 
     async def test_tv_channel_int_and_direction(self):
@@ -974,18 +1011,18 @@ class TestTvFlows:
             "playing",
             {"volume_level": 0.5},
         )
-        hass.states.get = MagicMock(
-            return_value=_mock_ha_state("playing", {"volume_level": 0.5})
-        )
+        hass.states.get = MagicMock(return_value=_mock_ha_state("playing", {"volume_level": 0.5}))
 
         # channel_int=5 -> play_media
-        payload = _sber_cmd_payload({
-            "media_player.tv": {
-                "states": [
-                    {"key": "channel_int", "value": {"type": "INTEGER", "integer_value": 5}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "media_player.tv": {
+                    "states": [
+                        {"key": "channel_int", "value": {"type": "INTEGER", "integer_value": 5}},
+                    ],
+                },
+            }
+        )
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
             new_callable=AsyncMock,
@@ -1002,13 +1039,15 @@ class TestTvFlows:
         # direction=ok -> media_play_pause
         hass.services.async_call.reset_mock()
         hass._created_tasks.clear()
-        payload = _sber_cmd_payload({
-            "media_player.tv": {
-                "states": [
-                    {"key": "direction", "value": {"type": "ENUM", "enum_value": "ok"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "media_player.tv": {
+                    "states": [
+                        {"key": "direction", "value": {"type": "ENUM", "enum_value": "ok"}},
+                    ],
+                },
+            }
+        )
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
             new_callable=AsyncMock,
@@ -1023,13 +1062,15 @@ class TestTvFlows:
         # channel="+" -> media_next_track
         hass.services.async_call.reset_mock()
         hass._created_tasks.clear()
-        payload = _sber_cmd_payload({
-            "media_player.tv": {
-                "states": [
-                    {"key": "channel", "value": {"type": "ENUM", "enum_value": "+"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "media_player.tv": {
+                    "states": [
+                        {"key": "channel", "value": {"type": "ENUM", "enum_value": "+"}},
+                    ],
+                },
+            }
+        )
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
             new_callable=AsyncMock,
@@ -1063,15 +1104,19 @@ class TestVacuumFlows:
 
         # Command: start
         hass.states.get = MagicMock(
-            return_value=_mock_ha_state("cleaning", {"fan_speed": "standard", "fan_speed_list": ["quiet", "standard", "turbo"]})
+            return_value=_mock_ha_state(
+                "cleaning", {"fan_speed": "standard", "fan_speed_list": ["quiet", "standard", "turbo"]}
+            )
         )
-        payload = _sber_cmd_payload({
-            "vacuum.robo": {
-                "states": [
-                    {"key": "vacuum_cleaner_command", "value": {"type": "ENUM", "enum_value": "start"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "vacuum.robo": {
+                    "states": [
+                        {"key": "vacuum_cleaner_command", "value": {"type": "ENUM", "enum_value": "start"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -1095,18 +1140,22 @@ class TestVacuumFlows:
         # Command: return_to_dock
         hass.services.async_call.reset_mock()
         hass._created_tasks.clear()
-        bridge._mqtt_client.publish.reset_mock()
+        bridge._mqtt_service.publish.reset_mock()
 
         hass.states.get = MagicMock(
-            return_value=_mock_ha_state("returning", {"fan_speed": "standard", "fan_speed_list": ["quiet", "standard", "turbo"]})
+            return_value=_mock_ha_state(
+                "returning", {"fan_speed": "standard", "fan_speed_list": ["quiet", "standard", "turbo"]}
+            )
         )
-        payload = _sber_cmd_payload({
-            "vacuum.robo": {
-                "states": [
-                    {"key": "vacuum_cleaner_command", "value": {"type": "ENUM", "enum_value": "return_to_dock"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "vacuum.robo": {
+                    "states": [
+                        {"key": "vacuum_cleaner_command", "value": {"type": "ENUM", "enum_value": "return_to_dock"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -1125,9 +1174,7 @@ class TestVacuumFlows:
         device_states = payloads[-1]["devices"]["vacuum.robo"]["states"]
         status_val = _find_state_value(device_states, "vacuum_cleaner_status")
         assert status_val is not None
-        assert status_val["enum_value"] == "go_home", (
-            "Sber expects 'go_home', not 'returning'"
-        )
+        assert status_val["enum_value"] == "go_home", "Sber expects 'go_home', not 'returning'"
 
 
 # ---------------------------------------------------------------------------
@@ -1148,18 +1195,18 @@ class TestFanFlows:
             "on",
             {"percentage": 50},
         )
-        hass.states.get = MagicMock(
-            return_value=_mock_ha_state("on", {"percentage": 75})
-        )
+        hass.states.get = MagicMock(return_value=_mock_ha_state("on", {"percentage": 75}))
 
         # on_off=true
-        payload = _sber_cmd_payload({
-            "fan.ceiling": {
-                "states": [
-                    {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "fan.ceiling": {
+                    "states": [
+                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -1175,15 +1222,17 @@ class TestFanFlows:
         # hvac_air_flow_power=high -> set_percentage (no preset_modes available)
         hass.services.async_call.reset_mock()
         hass._created_tasks.clear()
-        bridge._mqtt_client.publish.reset_mock()
+        bridge._mqtt_service.publish.reset_mock()
 
-        payload = _sber_cmd_payload({
-            "fan.ceiling": {
-                "states": [
-                    {"key": "hvac_air_flow_power", "value": {"type": "ENUM", "enum_value": "high"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "fan.ceiling": {
+                    "states": [
+                        {"key": "hvac_air_flow_power", "value": {"type": "ENUM", "enum_value": "high"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -1209,11 +1258,13 @@ class TestSensorFlows:
     async def test_linked_sensor_propagation(self):
         """Linked humidity update triggers significant change and appears in state."""
         entity = SensorTempEntity({"entity_id": "sensor.temp", "name": "Temperature"})
-        entity.fill_by_ha_state({
-            "entity_id": "sensor.temp",
-            "state": "22.5",
-            "attributes": {},
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "sensor.temp",
+                "state": "22.5",
+                "attributes": {},
+            }
+        )
         entity.mark_state_published()
 
         # Update linked humidity
@@ -1233,22 +1284,26 @@ class TestSensorFlows:
         entity = MotionSensorEntity({"entity_id": "binary_sensor.motion", "name": "Motion"})
 
         # Motion detected
-        entity.fill_by_ha_state({
-            "entity_id": "binary_sensor.motion",
-            "state": "on",
-            "attributes": {},
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "binary_sensor.motion",
+                "state": "on",
+                "attributes": {},
+            }
+        )
         state = entity.to_sber_current_state()
         states_list = state["binary_sensor.motion"]["states"]
         pir_entry = _find_state_entry(states_list, "pir")
         assert pir_entry is not None, "pir key must be present when motion detected"
 
         # No motion
-        entity.fill_by_ha_state({
-            "entity_id": "binary_sensor.motion",
-            "state": "off",
-            "attributes": {},
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "binary_sensor.motion",
+                "state": "off",
+                "attributes": {},
+            }
+        )
         state = entity.to_sber_current_state()
         states_list = state["binary_sensor.motion"]["states"]
         pir_entry = _find_state_entry(states_list, "pir")
@@ -1257,11 +1312,13 @@ class TestSensorFlows:
     async def test_temp_humidity_same_device(self):
         """Temperature sensor with linked humidity reports both in state."""
         entity = SensorTempEntity({"entity_id": "sensor.temp", "name": "TempSensor"})
-        entity.fill_by_ha_state({
-            "entity_id": "sensor.temp",
-            "state": "21.0",
-            "attributes": {},
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "sensor.temp",
+                "state": "21.0",
+                "attributes": {},
+            }
+        )
 
         # Link humidity
         entity.update_linked_data("humidity", {"state": "55", "attributes": {}})
@@ -1294,13 +1351,15 @@ class TestValveFlows:
 
         hass.states.get = MagicMock(return_value=_mock_ha_state("closed"))
 
-        payload = _sber_cmd_payload({
-            "valve.water": {
-                "states": [
-                    {"key": "open_set", "value": {"type": "ENUM", "enum_value": "close"}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "valve.water": {
+                    "states": [
+                        {"key": "open_set", "value": {"type": "ENUM", "enum_value": "close"}},
+                    ],
+                },
+            }
+        )
 
         with patch(
             "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
@@ -1391,7 +1450,7 @@ def _make_entry_for_real_hass(options=None):
 def _extract_published_states(bridge) -> list[dict]:
     """Return all published up/status payloads from the mqtt mock."""
     results = []
-    for call in bridge._mqtt_client.publish.call_args_list:
+    for call in bridge._mqtt_service.publish.call_args_list:
         args = call.args if call.args else call[0]
         topic = str(args[0])
         if "up/status" in topic:
@@ -1422,15 +1481,18 @@ class TestRealHassFlows:
         entry = _make_entry_for_real_hass()
         bridge = SberBridge(hass, entry)
         bridge._mqtt_client = AsyncMock()
+        bridge._mqtt_service.publish = AsyncMock()
         bridge._connected = True
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
 
         entity = RelayEntity({"entity_id": "switch.lamp", "name": "Test Lamp"})
-        entity.fill_by_ha_state({
-            "entity_id": "switch.lamp",
-            "state": "off",
-            "attributes": {},
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "switch.lamp",
+                "state": "off",
+                "attributes": {},
+            }
+        )
         bridge._entities["switch.lamp"] = entity
         bridge._enabled_entity_ids = ["switch.lamp"]
 
@@ -1471,8 +1533,9 @@ class TestRealHassFlows:
         entry = _make_entry_for_real_hass()
         bridge = SberBridge(hass, entry)
         bridge._mqtt_client = AsyncMock()
+        bridge._mqtt_service.publish = AsyncMock()
         bridge._connected = True
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
 
         initial_attrs = {
             "brightness": 255,
@@ -1481,11 +1544,13 @@ class TestRealHassFlows:
             "color_temp": 300,
         }
         entity = LightEntity({"entity_id": "light.test", "name": "Test Light"})
-        entity.fill_by_ha_state({
-            "entity_id": "light.test",
-            "state": "on",
-            "attributes": initial_attrs,
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "light.test",
+                "state": "on",
+                "attributes": initial_attrs,
+            }
+        )
         entity.mark_state_published()
         bridge._entities["light.test"] = entity
         bridge._enabled_entity_ids = ["light.test"]
@@ -1497,13 +1562,17 @@ class TestRealHassFlows:
         bridge._subscribe_ha_events()
 
         # Act: change to rgb color mode
-        hass.states.async_set("light.test", "on", {
-            "color_mode": "rgb",
-            "hs_color": (283.0, 100.0),
-            "rgb_color": (70, 0, 255),
-            "brightness": 255,
-            "supported_color_modes": ["color_temp", "hs", "rgb"],
-        })
+        hass.states.async_set(
+            "light.test",
+            "on",
+            {
+                "color_mode": "rgb",
+                "hs_color": (283.0, 100.0),
+                "rgb_color": (70, 0, 255),
+                "brightness": 255,
+                "supported_color_modes": ["color_temp", "hs", "rgb"],
+            },
+        )
         await hass.async_block_till_done()
 
         async_fire_time_changed(hass, fire_all=True)
@@ -1517,8 +1586,7 @@ class TestRealHassFlows:
         mode_val = _find_state_value(device_states, "light_mode")
         assert mode_val is not None
         assert mode_val["enum_value"] == "colour", (
-            "Expected light_mode='colour' after switching to rgb, "
-            f"got '{mode_val.get('enum_value')}'"
+            f"Expected light_mode='colour' after switching to rgb, got '{mode_val.get('enum_value')}'"
         )
 
         colour_val = _find_state_value(device_states, "light_colour")
@@ -1537,15 +1605,18 @@ class TestRealHassFlows:
         entry = _make_entry_for_real_hass()
         bridge = SberBridge(hass, entry)
         bridge._mqtt_client = AsyncMock()
+        bridge._mqtt_service.publish = AsyncMock()
         bridge._connected = True
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
 
         entity = RelayEntity({"entity_id": "switch.lamp", "name": "Test Lamp"})
-        entity.fill_by_ha_state({
-            "entity_id": "switch.lamp",
-            "state": "off",
-            "attributes": {},
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "switch.lamp",
+                "state": "off",
+                "attributes": {},
+            }
+        )
         bridge._entities["switch.lamp"] = entity
         bridge._enabled_entity_ids = ["switch.lamp"]
 
@@ -1590,17 +1661,18 @@ class TestRealHassFlows:
         entry = _make_entry_for_real_hass()
         bridge = SberBridge(hass, entry)
         bridge._mqtt_client = AsyncMock()
+        bridge._mqtt_service.publish = AsyncMock()
         bridge._connected = True
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
 
-        entity = MotionSensorEntity(
-            {"entity_id": "binary_sensor.pir", "name": "PIR"}
+        entity = MotionSensorEntity({"entity_id": "binary_sensor.pir", "name": "PIR"})
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "binary_sensor.pir",
+                "state": "off",
+                "attributes": {},
+            }
         )
-        entity.fill_by_ha_state({
-            "entity_id": "binary_sensor.pir",
-            "state": "off",
-            "attributes": {},
-        })
         bridge._entities["binary_sensor.pir"] = entity
         bridge._enabled_entity_ids = ["binary_sensor.pir"]
 
@@ -1622,7 +1694,7 @@ class TestRealHassFlows:
         assert pir_entry is not None, "pir key must be present when motion detected"
 
         # Reset publish mock for second assertion
-        bridge._mqtt_client.publish.reset_mock()
+        bridge._mqtt_service.publish.reset_mock()
 
         # Act 2: motion cleared
         hass.states.async_set("binary_sensor.pir", "off")
@@ -1648,17 +1720,18 @@ class TestRealHassFlows:
         entry = _make_entry_for_real_hass()
         bridge = SberBridge(hass, entry)
         bridge._mqtt_client = AsyncMock()
+        bridge._mqtt_service.publish = AsyncMock()
         bridge._connected = True
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
 
-        entity = CurtainEntity(
-            {"entity_id": "cover.curtain", "name": "Test Curtain"}
+        entity = CurtainEntity({"entity_id": "cover.curtain", "name": "Test Curtain"})
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "cover.curtain",
+                "state": "open",
+                "attributes": {"current_position": 100},
+            }
         )
-        entity.fill_by_ha_state({
-            "entity_id": "cover.curtain",
-            "state": "open",
-            "attributes": {"current_position": 100},
-        })
         bridge._entities["cover.curtain"] = entity
         bridge._enabled_entity_ids = ["cover.curtain"]
 
@@ -1679,9 +1752,7 @@ class TestRealHassFlows:
         device_states = payloads[-1]["devices"]["cover.curtain"]["states"]
         open_state_val = _find_state_value(device_states, "open_state")
         assert open_state_val is not None
-        assert open_state_val["enum_value"] == "close", (
-            "Sber requires 'close', not 'closed'"
-        )
+        assert open_state_val["enum_value"] == "close", "Sber requires 'close', not 'closed'"
 
         open_pct_val = _find_state_value(device_states, "open_percentage")
         assert open_pct_val is not None
@@ -1700,15 +1771,18 @@ class TestRealHassFlows:
         entry = _make_entry_for_real_hass()
         bridge = SberBridge(hass, entry)
         bridge._mqtt_client = AsyncMock()
+        bridge._mqtt_service.publish = AsyncMock()
         bridge._connected = True
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
 
         entity = RelayEntity({"entity_id": "switch.lamp", "name": "Test Lamp"})
-        entity.fill_by_ha_state({
-            "entity_id": "switch.lamp",
-            "state": "off",
-            "attributes": {},
-        })
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "switch.lamp",
+                "state": "off",
+                "attributes": {},
+            }
+        )
         bridge._entities["switch.lamp"] = entity
         bridge._enabled_entity_ids = ["switch.lamp"]
 
@@ -1725,13 +1799,15 @@ class TestRealHassFlows:
             if service == "turn_on":
                 hass.states.async_set("switch.lamp", "on", {})
 
-        payload = _sber_cmd_payload({
-            "switch.lamp": {
-                "states": [
-                    {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}},
-                ],
-            },
-        })
+        payload = _sber_cmd_payload(
+            {
+                "switch.lamp": {
+                    "states": [
+                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}},
+                    ],
+                },
+            }
+        )
 
         with (
             patch(
@@ -1751,12 +1827,8 @@ class TestRealHassFlows:
             await hass.async_block_till_done()
 
         # Assert: service call was made for turn_on
-        turn_on_calls = [
-            c for c in service_calls if c[1] == "turn_on"
-        ]
-        assert len(turn_on_calls) >= 1, (
-            f"Expected turn_on service call, got: {service_calls}"
-        )
+        turn_on_calls = [c for c in service_calls if c[1] == "turn_on"]
+        assert len(turn_on_calls) >= 1, f"Expected turn_on service call, got: {service_calls}"
 
         # Assert: MQTT publish was called with on_off=true
         payloads = _extract_published_states(bridge)
@@ -1781,17 +1853,18 @@ class TestRealHassFlows:
         entry = _make_entry_for_real_hass()
         bridge = SberBridge(hass, entry)
         bridge._mqtt_client = AsyncMock()
+        bridge._mqtt_service.publish = AsyncMock()
         bridge._connected = True
-        bridge._awaiting_sber_ack = False
+        bridge._ack_guard.clear()
 
-        entity = SensorTempEntity(
-            {"entity_id": "sensor.temp", "name": "Temperature"}
+        entity = SensorTempEntity({"entity_id": "sensor.temp", "name": "Temperature"})
+        entity.fill_by_ha_state(
+            {
+                "entity_id": "sensor.temp",
+                "state": "22.5",
+                "attributes": {},
+            }
         )
-        entity.fill_by_ha_state({
-            "entity_id": "sensor.temp",
-            "state": "22.5",
-            "attributes": {},
-        })
         entity.mark_state_published()
 
         bridge._entities["sensor.temp"] = entity
@@ -1826,6 +1899,4 @@ class TestRealHassFlows:
         assert temp_val is not None, "temperature must be present in published state"
 
         humidity_val = _find_state_value(device_states, "humidity")
-        assert humidity_val is not None, (
-            "humidity must be present after linked sensor update"
-        )
+        assert humidity_val is not None, "humidity must be present after linked sensor update"


### PR DESCRIPTION
## Summary

All 7 architecture debt items from `ARCHITECTURE_RESEARCH.md` §10 resolved:

- **10.1** `LightEntity.LINKABLE_ROLES = SENSOR_LINK_ROLES` — Zigbee light battery/signal sensors now linkable
- **10.2** Publish through `MqttClientService.publish()` — dead code activated
- **10.3** `BridgeCommandContext` Protocol — decoupled dispatcher from full bridge ref
- **10.4** `ReconnectAckGuard` extracted — scattered ack state consolidated
- **10.5** `CONF_CONFIRM_DELAY` — hardcoded `1.5s` moved to SETTINGS_DEFAULTS
- **10.6** `CommandResult` TypedDict — typed `process_cmd` returns across 14 device classes
- **10.7** `AttrSpec.converter` — all 8 complex device classes migrated to declarative parsing (tv, hvac_fan, hvac_air_purifier, humidifier, kettle, vacuum_cleaner, light, climate)

## Test plan

- [x] 1556/1556 tests pass locally
- [x] `ruff check` + `ruff format` clean
- [ ] CI: Test 3.13, Test 3.14, Lint, Hassfest, HACS, CodeQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)