### PR TITLE
refactor: code review cleanup batch 2 (4 fixes)

### DIFF
--- a/custom_components/sber_mqtt_bridge/const.py
+++ b/custom_components/sber_mqtt_bridge/const.py
@@ -47,9 +47,6 @@ CONF_MESSAGE_LOG_SIZE = "message_log_size"
 CONF_MAX_MQTT_PAYLOAD = "max_mqtt_payload_size"
 """Options key for maximum allowed MQTT payload size in bytes."""
 
-CONF_CONTEXT_CLEANUP_THRESHOLD = "context_cleanup_threshold"
-"""Options key for echo-loop context ID set cleanup threshold."""
-
 CONF_HUB_AUTO_PARENT = "hub_auto_parent_id"
 """Options key for auto-assigning parent_id=root to all child devices."""
 
@@ -65,7 +62,6 @@ SETTINGS_DEFAULTS: dict[str, int | float | bool] = {
     CONF_DEBOUNCE_DELAY: 0.1,
     CONF_MESSAGE_LOG_SIZE: 50,
     CONF_MAX_MQTT_PAYLOAD: 1_000_000,
-    CONF_CONTEXT_CLEANUP_THRESHOLD: 200,
     CONF_SBER_VERIFY_SSL: True,
     CONF_HUB_AUTO_PARENT: False,
     CONF_CONFIRM_DELAY: 1.5,

--- a/custom_components/sber_mqtt_bridge/devices/base_entity.py
+++ b/custom_components/sber_mqtt_bridge/devices/base_entity.py
@@ -229,6 +229,18 @@ class BaseEntity(ABC):
     LINKABLE_ROLES: ClassVar[tuple[LinkableRole, ...]] = ()
     """Linkable roles this device class accepts. Override in subclasses."""
 
+    def register_link(self, role: str, linked_entity_id: str) -> None:
+        """Register a linked companion entity for the given role.
+
+        Public API for :class:`SberEntityLoader` — replaces direct mutation
+        of ``self._linked_entities`` to preserve encapsulation.
+
+        Args:
+            role: The role name (e.g. ``"battery"``, ``"signal_strength"``).
+            linked_entity_id: HA entity_id of the linked companion.
+        """
+        self._linked_entities[role] = linked_entity_id
+
     ATTR_SPECS: ClassVar[tuple[AttrSpec, ...]] = ()
     """Declarative HA-attribute parsing specs.
 

--- a/custom_components/sber_mqtt_bridge/entity_registry.py
+++ b/custom_components/sber_mqtt_bridge/entity_registry.py
@@ -252,6 +252,17 @@ class SberEntityLoader:
             primary_entity = new_entities[primary_id]
             valid_roles: dict[str, str] = {}
             for role, linked_id in roles.items():
+                # Guard: prevent linking an entity that is itself a primary —
+                # would cause duplicate publication to Sber cloud.
+                if linked_id in new_entities:
+                    _LOGGER.warning(
+                        "Entity %s is both a primary and a linked sensor for %s "
+                        "(role=%s) — link ignored to prevent duplicate publication",
+                        linked_id,
+                        primary_id,
+                        role,
+                    )
+                    continue
                 valid_roles[role] = linked_id
                 new_reverse[linked_id] = (primary_id, role)
                 linked_state = self._hass.states.get(linked_id)
@@ -271,7 +282,7 @@ class SberEntityLoader:
                         "attributes": dict(linked_state.attributes),
                     }
                     primary_entity.update_linked_data(role, ha_state_dict)
-                    primary_entity._linked_entities[role] = linked_id
+                    primary_entity.register_link(role, linked_id)
             if valid_roles:
                 new_links[primary_id] = valid_roles
                 _LOGGER.info("Entity links for %s: %s", primary_id, valid_roles)

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -915,10 +915,6 @@ class SberBridge:
         """
         await self._publish_states([entity_id])
 
-    async def async_republish(self) -> None:
-        """Force republish full device config to Sber cloud."""
-        await self._publish_config()
-
     async def _publish_states(self, entity_ids: list[str] | None = None, *, force: bool = False) -> None:
         """Publish entity states to Sber MQTT.
 

--- a/custom_components/sber_mqtt_bridge/websocket_api/status.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/status.py
@@ -159,7 +159,7 @@ async def ws_republish(
     if bridge is None:
         connection.send_error(msg["id"], "bridge_not_found", "Sber bridge not available")
         return
-    await bridge.async_republish()
+    await bridge.async_republish_config()
     connection.send_result(msg["id"], {"success": True})
 
 


### PR DESCRIPTION
## Issues fixed

- **#6** `BaseEntity.register_link()` public API — `SberEntityLoader` no longer mutates `_linked_entities` directly
- **#8** Removed duplicate `async_republish()` (kept `async_republish_config`)
- **#11** Removed unused `CONF_CONTEXT_CLEANUP_THRESHOLD`
- **#12** Guard against entity being both primary and linked (duplicate publication prevention)

1653/1653 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)