### PR TITLE
feat: unified Sber spec artifact (categories + functions)

### DIFF
--- a/tests/hacs/__snapshots__/sber_full_spec.json
+++ b/tests/hacs/__snapshots__/sber_full_spec.json
@@ -1,0 +1,1448 @@
+{
+  "categories": {
+    "curtain": {
+      "allowed_values": {
+        "open_rate": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "low",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "curtain",
+      "dependencies": {},
+      "features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "open_left_percentage",
+        "open_rate",
+        "open_right_percentage",
+        "open_right_set",
+        "open_right_state",
+        "open_set",
+        "open_state",
+        "signal_strength"
+      ]
+    },
+    "gate": {
+      "allowed_values": {
+        "open_rate": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "low",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "gate",
+      "dependencies": {},
+      "features": [
+        "online",
+        "open_left_percentage",
+        "open_left_set",
+        "open_left_state",
+        "open_rate",
+        "open_right_percentage",
+        "open_right_set",
+        "open_right_state",
+        "open_set",
+        "open_state",
+        "signal_strength"
+      ]
+    },
+    "hub": {
+      "allowed_values": {},
+      "category": "hub",
+      "dependencies": {},
+      "features": [
+        "online"
+      ]
+    },
+    "hvac_ac": {
+      "allowed_values": {
+        "hvac_air_flow_power": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "high",
+              "low",
+              "medium",
+              "turbo"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "hvac_ac",
+      "dependencies": {},
+      "features": [
+        "hvac_air_flow_direction",
+        "hvac_air_flow_power",
+        "hvac_humidity_set",
+        "hvac_night_mode",
+        "hvac_temp_set",
+        "hvac_work_mode",
+        "on_off",
+        "online"
+      ]
+    },
+    "hvac_air_purifier": {
+      "allowed_values": {
+        "hvac_air_flow_power": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "high",
+              "low",
+              "medium",
+              "turbo"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "hvac_air_purifier",
+      "dependencies": {},
+      "features": [
+        "hvac_air_flow_power",
+        "hvac_aromatization",
+        "hvac_ionization",
+        "hvac_night_mode",
+        "hvac_replace_filter",
+        "hvac_replace_ionizator",
+        "on_off",
+        "online"
+      ]
+    },
+    "hvac_boiler": {
+      "allowed_values": {
+        "hvac_temp_set": {
+          "integer_values": {
+            "max": "80",
+            "min": "25",
+            "step": "5"
+          },
+          "type": "INTEGER"
+        }
+      },
+      "category": "hvac_boiler",
+      "dependencies": {},
+      "features": [
+        "hvac_temp_set",
+        "hvac_thermostat_mode",
+        "on_off",
+        "online",
+        "temperature"
+      ]
+    },
+    "hvac_fan": {
+      "allowed_values": {
+        "hvac_air_flow_power": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "high",
+              "low",
+              "medium",
+              "turbo"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "hvac_fan",
+      "dependencies": {},
+      "features": [
+        "hvac_air_flow_power",
+        "on_off",
+        "online"
+      ]
+    },
+    "hvac_heater": {
+      "allowed_values": {
+        "hvac_air_flow_power": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "high",
+              "low",
+              "medium",
+              "turbo"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "hvac_heater",
+      "dependencies": {},
+      "features": [
+        "hvac_air_flow_power",
+        "hvac_temp_set",
+        "hvac_thermostat_mode",
+        "on_off",
+        "online",
+        "temperature"
+      ]
+    },
+    "hvac_humidifier": {
+      "allowed_values": {
+        "hvac_air_flow_power": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "high",
+              "low",
+              "medium",
+              "turbo"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "hvac_humidifier",
+      "dependencies": {},
+      "features": [
+        "humidity",
+        "hvac_air_flow_power",
+        "hvac_humidity_set",
+        "hvac_ionization",
+        "hvac_night_mode",
+        "hvac_replace_filter",
+        "hvac_replace_ionizator",
+        "hvac_water_low_level",
+        "hvac_water_percentage",
+        "on_off",
+        "online"
+      ]
+    },
+    "hvac_radiator": {
+      "allowed_values": {
+        "hvac_temp_set": {
+          "integer_values": {
+            "max": "40",
+            "min": "25",
+            "step": "5"
+          },
+          "type": "INTEGER"
+        }
+      },
+      "category": "hvac_radiator",
+      "dependencies": {},
+      "features": [
+        "hvac_temp_set",
+        "on_off",
+        "online",
+        "temperature"
+      ]
+    },
+    "hvac_underfloor_heating": {
+      "allowed_values": {
+        "hvac_temp_set": {
+          "integer_values": {
+            "max": "50",
+            "min": "25",
+            "step": "5"
+          },
+          "type": "INTEGER"
+        }
+      },
+      "category": "hvac_underfloor_heating",
+      "dependencies": {},
+      "features": [
+        "hvac_temp_set",
+        "hvac_thermostat_mode",
+        "on_off",
+        "online",
+        "temperature"
+      ]
+    },
+    "intercom": {
+      "allowed_values": {},
+      "category": "intercom",
+      "dependencies": {},
+      "features": [
+        "incoming_call",
+        "online",
+        "reject_call",
+        "unlock"
+      ]
+    },
+    "kettle": {
+      "allowed_values": {
+        "kitchen_water_temperature_set": {
+          "integer_values": {
+            "max": "100",
+            "min": "60",
+            "step": "10"
+          },
+          "type": "INTEGER"
+        }
+      },
+      "category": "kettle",
+      "dependencies": {},
+      "features": [
+        "child_lock",
+        "kitchen_water_level",
+        "kitchen_water_low_level",
+        "kitchen_water_temperature",
+        "kitchen_water_temperature_set",
+        "on_off",
+        "online"
+      ]
+    },
+    "led_strip": {
+      "allowed_values": {
+        "light_brightness": {
+          "integer_values": {
+            "max": "900",
+            "min": "100",
+            "step": "1"
+          },
+          "type": "INTEGER"
+        }
+      },
+      "category": "led_strip",
+      "dependencies": {},
+      "features": [
+        "light_brightness",
+        "light_colour",
+        "light_colour_temp",
+        "light_mode",
+        "on_off",
+        "online",
+        "sleep_timer"
+      ]
+    },
+    "light": {
+      "allowed_values": {
+        "light_brightness": {
+          "integer_values": {
+            "max": "900",
+            "min": "100",
+            "step": "1"
+          },
+          "type": "INTEGER"
+        }
+      },
+      "category": "light",
+      "dependencies": {},
+      "features": [
+        "light_brightness",
+        "light_colour",
+        "light_colour_temp",
+        "light_mode",
+        "on_off",
+        "online"
+      ]
+    },
+    "relay": {
+      "allowed_values": {
+        "power": {
+          "integer_values": {
+            "max": "45000",
+            "min": "10",
+            "step": "1"
+          },
+          "type": "INTEGER"
+        }
+      },
+      "category": "relay",
+      "dependencies": {},
+      "features": [
+        "current",
+        "on_off",
+        "online",
+        "power",
+        "voltage"
+      ]
+    },
+    "scenario_button": {
+      "allowed_values": {
+        "button_1_event": {
+          "enum_values": {
+            "values": [
+              "click",
+              "double_click"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "scenario_button",
+      "dependencies": {},
+      "features": [
+        "battery_percentag",
+        "button_1_event",
+        "button_2_event",
+        "online",
+        "signal_strength"
+      ]
+    },
+    "sensor_door": {
+      "allowed_values": {
+        "sensor_sensitive": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "sensor_door",
+      "dependencies": {},
+      "features": [
+        "battery_low_power",
+        "battery_percentage",
+        "doorcontact_state",
+        "online",
+        "sensor_sensitive",
+        "signal_strength",
+        "tamper_alarm"
+      ]
+    },
+    "sensor_gas": {
+      "allowed_values": {
+        "signal_strength": {
+          "enum_values": {
+            "values": [
+              "low",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "sensor_gas",
+      "dependencies": {},
+      "features": [
+        "alarm_mute",
+        "battery_low_power",
+        "battery_percentage",
+        "gas_leak_state",
+        "online",
+        "sensor_sensitive",
+        "signal_strength"
+      ]
+    },
+    "sensor_pir": {
+      "allowed_values": {
+        "sensor_sensitive": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "sensor_pir",
+      "dependencies": {},
+      "features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "pir",
+        "sensor_sensitive",
+        "signal_strength"
+      ]
+    },
+    "sensor_smoke": {
+      "allowed_values": {
+        "signal_strength": {
+          "enum_values": {
+            "values": [
+              "low",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "sensor_smoke",
+      "dependencies": {},
+      "features": [
+        "alarm_mute",
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "signal_strength",
+        "smoke_state"
+      ]
+    },
+    "sensor_temp": {
+      "allowed_values": {
+        "sensor_sensitive": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "sensor_temp",
+      "dependencies": {},
+      "features": [
+        "air_pressure",
+        "battery_low_power",
+        "battery_percentage",
+        "humidity",
+        "online",
+        "sensor_sensitive",
+        "signal_strength",
+        "temp_unit_view",
+        "temperature"
+      ]
+    },
+    "sensor_water_leak": {
+      "allowed_values": {
+        "signal_strength": {
+          "enum_values": {
+            "values": [
+              "low",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "sensor_water_leak",
+      "dependencies": {},
+      "features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "signal_strength",
+        "water_leak_state"
+      ]
+    },
+    "socket": {
+      "allowed_values": {
+        "power": {
+          "integer_values": {
+            "max": "45000",
+            "min": "10",
+            "step": "1"
+          },
+          "type": "INTEGER"
+        }
+      },
+      "category": "socket",
+      "dependencies": {},
+      "features": [
+        "child_lock",
+        "current",
+        "on_off",
+        "online",
+        "power",
+        "voltage"
+      ]
+    },
+    "tv": {
+      "allowed_values": {
+        "source": {
+          "enum_values": {
+            "values": [
+              "hdmi1",
+              "hdmi2",
+              "hdmi3",
+              "tv",
+              "av",
+              "content",
+              "+",
+              "-"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "tv",
+      "dependencies": {},
+      "features": [
+        "channel",
+        "channel_int",
+        "custom_key",
+        "direction",
+        "mute",
+        "number",
+        "on_off",
+        "online",
+        "source",
+        "volume",
+        "volume_int"
+      ]
+    },
+    "vacuum_cleaner": {
+      "allowed_values": {
+        "vacuum_cleaner_program": {
+          "enum_values": {
+            "values": [
+              "perimeter",
+              "spot",
+              "smart"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "vacuum_cleaner",
+      "dependencies": {},
+      "features": [
+        "battery_percentage",
+        "child_lock",
+        "online",
+        "vacuum_cleaner_cleaning_type",
+        "vacuum_cleaner_command",
+        "vacuum_cleaner_program",
+        "vacuum_cleaner_status"
+      ]
+    },
+    "valve": {
+      "allowed_values": {
+        "signal_strength": {
+          "enum_values": {
+            "values": [
+              "low",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "valve",
+      "dependencies": {},
+      "features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "open_set",
+        "open_state",
+        "signal_strength"
+      ]
+    },
+    "window_blind": {
+      "allowed_values": {
+        "open_rate": {
+          "enum_values": {
+            "values": [
+              "auto",
+              "low",
+              "high"
+            ]
+          },
+          "type": "ENUM"
+        }
+      },
+      "category": "window_blind",
+      "dependencies": {},
+      "features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "open_percentage",
+        "open_rate",
+        "open_set",
+        "open_state",
+        "signal_strength"
+      ]
+    }
+  },
+  "functions": {
+    "air_pressure": {
+      "name": "air_pressure",
+      "range": "200, 800",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "sensor_temp"
+      ]
+    },
+    "alarm_mute": {
+      "name": "alarm_mute",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "sensor_gas",
+        "sensor_smoke"
+      ]
+    },
+    "battery_low_power": {
+      "name": "battery_low_power",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "curtain",
+        "scenario_button",
+        "sensor_door",
+        "sensor_gas",
+        "sensor_pir",
+        "sensor_smoke",
+        "sensor_temp",
+        "sensor_water_leak",
+        "valve",
+        "window_blind"
+      ]
+    },
+    "battery_percentage": {
+      "name": "battery_percentage",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "scenario_button",
+        "sensor_door",
+        "sensor_gas",
+        "sensor_pir",
+        "sensor_smoke",
+        "sensor_temp",
+        "sensor_water_leak",
+        "vacuum_cleaner",
+        "valve",
+        "window_blind"
+      ]
+    },
+    "button_10_event": {
+      "name": "button_10_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_1_event": {
+      "name": "button_1_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_2_event": {
+      "name": "button_2_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_3_event": {
+      "name": "button_3_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_4_event": {
+      "name": "button_4_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_5_event": {
+      "name": "button_5_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_6_event": {
+      "name": "button_6_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": []
+    },
+    "button_7_event": {
+      "name": "button_7_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_8_event": {
+      "name": "button_8_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_9_event": {
+      "name": "button_9_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_bottom_left_event": {
+      "name": "button_bottom_left_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": []
+    },
+    "button_bottom_right_event": {
+      "name": "button_bottom_right_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_event": {
+      "name": "button_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_left_event": {
+      "name": "button_left_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": []
+    },
+    "button_right_event": {
+      "name": "button_right_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_top_left_event": {
+      "name": "button_top_left_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "button_top_right_event": {
+      "name": "button_top_right_event",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "scenario_button"
+      ]
+    },
+    "channel": {
+      "name": "channel",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "tv"
+      ]
+    },
+    "channel_int": {
+      "name": "channel_int",
+      "range": "0, 999",
+      "type": "INTEGER",
+      "used_in_categories": []
+    },
+    "child_lock": {
+      "name": "child_lock",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "kettle",
+        "socket",
+        "vacuum_cleaner"
+      ]
+    },
+    "current": {
+      "name": "current",
+      "range": "0, 30000",
+      "type": "INTEGER",
+      "used_in_categories": []
+    },
+    "custom_key": {
+      "name": "custom_key",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "tv"
+      ]
+    },
+    "direction": {
+      "name": "direction",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "tv"
+      ]
+    },
+    "doorcontact_state": {
+      "name": "doorcontact_state",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "sensor_door"
+      ]
+    },
+    "gas_leak_state": {
+      "name": "gas_leak_state",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "sensor_gas"
+      ]
+    },
+    "humidity": {
+      "name": "humidity",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "hvac_ac",
+        "hvac_humidifier",
+        "sensor_temp"
+      ]
+    },
+    "hvac_air_flow_direction": {
+      "name": "hvac_air_flow_direction",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "hvac_ac"
+      ]
+    },
+    "hvac_air_flow_power": {
+      "name": "hvac_air_flow_power",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "hvac_ac",
+        "hvac_air_purifier",
+        "hvac_fan",
+        "hvac_heater",
+        "hvac_humidifier"
+      ]
+    },
+    "hvac_aromatization": {
+      "name": "hvac_aromatization",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": []
+    },
+    "hvac_decontaminate": {
+      "name": "hvac_decontaminate",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "hvac_air_purifier"
+      ]
+    },
+    "hvac_direction_set": {
+      "name": "hvac_direction_set",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": []
+    },
+    "hvac_heating_rate": {
+      "name": "hvac_heating_rate",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "hvac_boiler",
+        "hvac_underfloor_heating"
+      ]
+    },
+    "hvac_humidity_set": {
+      "name": "hvac_humidity_set",
+      "range": "30, 90",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "hvac_ac",
+        "hvac_humidifier"
+      ]
+    },
+    "hvac_ionization": {
+      "name": "hvac_ionization",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "hvac_ac",
+        "hvac_air_purifier",
+        "hvac_humidifier"
+      ]
+    },
+    "hvac_night_mode": {
+      "name": "hvac_night_mode",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "hvac_ac",
+        "hvac_air_purifier",
+        "hvac_humidifier"
+      ]
+    },
+    "hvac_replace_filter": {
+      "name": "hvac_replace_filter",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "hvac_air_purifier",
+        "hvac_humidifier"
+      ]
+    },
+    "hvac_replace_ionizator": {
+      "name": "hvac_replace_ionizator",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "hvac_air_purifier",
+        "hvac_humidifier"
+      ]
+    },
+    "hvac_temp_set": {
+      "name": "hvac_temp_set",
+      "range": "5, 50",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "hvac_ac",
+        "hvac_boiler",
+        "hvac_heater",
+        "hvac_radiator",
+        "hvac_underfloor_heating"
+      ]
+    },
+    "hvac_thermostat_mode": {
+      "name": "hvac_thermostat_mode",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": []
+    },
+    "hvac_water_level": {
+      "name": "hvac_water_level",
+      "range": "0, 50",
+      "type": "FLOAT",
+      "used_in_categories": []
+    },
+    "hvac_water_low_level": {
+      "name": "hvac_water_low_level",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "hvac_humidifier"
+      ]
+    },
+    "hvac_water_percentage": {
+      "name": "hvac_water_percentage",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": []
+    },
+    "hvac_work_mode": {
+      "name": "hvac_work_mode",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "hvac_ac"
+      ]
+    },
+    "incoming_call": {
+      "name": "incoming_call",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "intercom"
+      ]
+    },
+    "kitchen_water_level": {
+      "name": "kitchen_water_level",
+      "range": "0, 50",
+      "type": "FLOAT",
+      "used_in_categories": [
+        "kettle"
+      ]
+    },
+    "kitchen_water_low_level": {
+      "name": "kitchen_water_low_level",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "kettle"
+      ]
+    },
+    "kitchen_water_temperature": {
+      "name": "kitchen_water_temperature",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": []
+    },
+    "kitchen_water_temperature_set": {
+      "name": "kitchen_water_temperature_set",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "kettle"
+      ]
+    },
+    "light_brightness": {
+      "name": "light_brightness",
+      "range": "50,1000",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "led_strip",
+        "light"
+      ]
+    },
+    "light_colour": {
+      "name": "light_colour",
+      "range": null,
+      "type": "COLOUR",
+      "used_in_categories": [
+        "led_strip",
+        "light"
+      ]
+    },
+    "light_colour_temp": {
+      "name": "light_colour_temp",
+      "range": "0, 1000",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "led_strip",
+        "light"
+      ]
+    },
+    "light_mode": {
+      "name": "light_mode",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "led_strip",
+        "light"
+      ]
+    },
+    "light_transmission_percentage": {
+      "name": "light_transmission_percentage",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "window_blind"
+      ]
+    },
+    "mute": {
+      "name": "mute",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "tv"
+      ]
+    },
+    "number": {
+      "name": "number",
+      "range": "0, 9",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "tv"
+      ]
+    },
+    "on_off": {
+      "name": "on_off",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "hvac_ac",
+        "hvac_air_purifier",
+        "hvac_fan",
+        "hvac_heater",
+        "hvac_radiator",
+        "hvac_underfloor_heating",
+        "kettle",
+        "led_strip",
+        "light",
+        "relay",
+        "socket"
+      ]
+    },
+    "online": {
+      "name": "online",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": []
+    },
+    "open_left_percentage": {
+      "name": "open_left_percentage",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "curtain",
+        "gate"
+      ]
+    },
+    "open_left_set": {
+      "name": "open_left_set",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "curtain",
+        "gate"
+      ]
+    },
+    "open_left_state": {
+      "name": "open_left_state",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "curtain",
+        "gate"
+      ]
+    },
+    "open_percentage": {
+      "name": "open_percentage",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "curtain",
+        "gate",
+        "valve",
+        "window_blind"
+      ]
+    },
+    "open_rate": {
+      "name": "open_rate",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "curtain",
+        "gate",
+        "window_blind"
+      ]
+    },
+    "open_right_percentage": {
+      "name": "open_right_percentage",
+      "range": "0, 100",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "curtain",
+        "gate"
+      ]
+    },
+    "open_right_set": {
+      "name": "open_right_set",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "curtain",
+        "gate"
+      ]
+    },
+    "open_right_state": {
+      "name": "open_right_state",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "curtain",
+        "gate"
+      ]
+    },
+    "open_set": {
+      "name": "open_set",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "curtain",
+        "gate",
+        "valve",
+        "window_blind"
+      ]
+    },
+    "open_state": {
+      "name": "open_state",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "curtain",
+        "gate",
+        "valve",
+        "window_blind"
+      ]
+    },
+    "pir": {
+      "name": "pir",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "sensor_pir"
+      ]
+    },
+    "power": {
+      "name": "power",
+      "range": "0, 50000",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "relay",
+        "socket"
+      ]
+    },
+    "reject_call": {
+      "name": "reject_call",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "intercom"
+      ]
+    },
+    "sensor_sensitive": {
+      "name": "sensor_sensitive",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "sensor_door",
+        "sensor_gas",
+        "sensor_pir",
+        "sensor_temp"
+      ]
+    },
+    "signal_strength": {
+      "name": "signal_strength",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "curtain",
+        "gate",
+        "scenario_button",
+        "sensor_door",
+        "sensor_gas",
+        "sensor_pir",
+        "sensor_smoke",
+        "sensor_temp",
+        "sensor_water_leak",
+        "valve",
+        "window_blind"
+      ]
+    },
+    "smoke_state": {
+      "name": "smoke_state",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "sensor_smoke"
+      ]
+    },
+    "source": {
+      "name": "source",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "tv"
+      ]
+    },
+    "tamper_alarm": {
+      "name": "tamper_alarm",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": [
+        "sensor_door"
+      ]
+    },
+    "temp_unit_view": {
+      "name": "temp_unit_view",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "sensor_temp"
+      ]
+    },
+    "temperature": {
+      "name": "temperature",
+      "range": "-400, 2000",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "hvac_ac",
+        "hvac_boiler",
+        "hvac_heater",
+        "hvac_radiator",
+        "hvac_underfloor_heating",
+        "sensor_temp"
+      ]
+    },
+    "unlock": {
+      "name": "unlock",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "intercom"
+      ]
+    },
+    "vacuum_cleaner_cleaning_type": {
+      "name": "vacuum_cleaner_cleaning_type",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "vacuum_cleaner"
+      ]
+    },
+    "vacuum_cleaner_command": {
+      "name": "vacuum_cleaner_command",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "vacuum_cleaner"
+      ]
+    },
+    "vacuum_cleaner_program": {
+      "name": "vacuum_cleaner_program",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "vacuum_cleaner"
+      ]
+    },
+    "vacuum_cleaner_status": {
+      "name": "vacuum_cleaner_status",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": [
+        "vacuum_cleaner"
+      ]
+    },
+    "voltage": {
+      "name": "voltage",
+      "range": "0, 5000",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "relay",
+        "socket"
+      ]
+    },
+    "volume": {
+      "name": "volume",
+      "range": null,
+      "type": "ENUM",
+      "used_in_categories": []
+    },
+    "volume_int": {
+      "name": "volume_int",
+      "range": "0, 999",
+      "type": "INTEGER",
+      "used_in_categories": [
+        "tv"
+      ]
+    },
+    "water_leak_state": {
+      "name": "water_leak_state",
+      "range": null,
+      "type": "BOOL",
+      "used_in_categories": []
+    }
+  },
+  "generated_at": "2026-04-12T21:05:04.890060+00:00",
+  "source": "https://developers.sber.ru/docs/ru/smarthome/c2c"
+}

--- a/tests/hacs/test_sber_compliance_live.py
+++ b/tests/hacs/test_sber_compliance_live.py
@@ -24,6 +24,7 @@ import pytest
 from custom_components.sber_mqtt_bridge.sber_models import CATEGORY_REQUIRED_FEATURES
 
 SNAPSHOT_FILE = Path(__file__).parent / "__snapshots__" / "sber_schemas.json"
+FULL_SPEC_FILE = Path(__file__).parent / "__snapshots__" / "sber_full_spec.json"
 
 
 @pytest.fixture(scope="module")
@@ -32,6 +33,20 @@ def sber_schemas() -> dict[str, dict]:
     if not SNAPSHOT_FILE.exists():
         pytest.skip(f"Snapshot file missing — run tools/fetch_sber_schemas.py: {SNAPSHOT_FILE}")
     return json.loads(SNAPSHOT_FILE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def sber_full_spec() -> dict:
+    """Load the unified Sber specification artifact (categories + functions)."""
+    if not FULL_SPEC_FILE.exists():
+        pytest.skip(f"Full spec missing — run tools/fetch_sber_schemas.py: {FULL_SPEC_FILE}")
+    return json.loads(FULL_SPEC_FILE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def sber_functions(sber_full_spec: dict) -> dict[str, dict]:
+    """Shortcut accessor for the functions catalog."""
+    return sber_full_spec.get("functions", {})
 
 
 class TestSberSchemasSnapshot:
@@ -92,3 +107,75 @@ class TestCategoryCoverage:
         our_cats = set(CATEGORY_REQUIRED_FEATURES.keys())
         new = sber_cats - our_cats
         assert not new, f"Sber added new categories not in our registry: {new}"
+
+
+class TestFunctionsCatalog:
+    """Validate the functions catalog and category cross-references."""
+
+    def test_functions_catalog_not_empty(self, sber_functions: dict[str, dict]) -> None:
+        """The catalog should contain at least 80 functions (Sber currently has ~90)."""
+        assert len(sber_functions) >= 80, f"Only {len(sber_functions)} functions found — scraper regression?"
+
+    def test_every_function_has_type(self, sber_functions: dict[str, dict]) -> None:
+        """Every function must have a Sber data type declared."""
+        missing_type = [name for name, spec in sber_functions.items() if not spec.get("type")]
+        assert not missing_type, f"Functions without type: {missing_type}"
+
+    def test_function_types_are_valid(self, sber_functions: dict[str, dict]) -> None:
+        """Function types must be one of the known Sber value types."""
+        valid_types = {"BOOL", "INTEGER", "FLOAT", "STRING", "ENUM", "COLOUR"}
+        for name, spec in sber_functions.items():
+            assert spec["type"] in valid_types, f"{name}: unknown type {spec['type']!r}"
+
+    # Features referenced by Sber category schemas that have no page on
+    # /functions. Either typos in Sber docs or undocumented features.
+    # Update this set only after verifying each entry is really a Sber-side
+    # documentation bug, not a scraper miss on our side.
+    KNOWN_SBER_DOC_ISSUES: frozenset[str] = frozenset(
+        {
+            "battery_percentag",  # typo in scenario_button ref model (missing 'e')
+            "sleep_timer",  # used in led_strip, no /functions page
+        }
+    )
+
+    def test_category_features_resolve_to_known_functions(
+        self,
+        sber_schemas: dict[str, dict],
+        sber_functions: dict[str, dict],
+    ) -> None:
+        """Every feature declared in any Sber category schema must exist in the functions catalog.
+
+        If this fails, either our scraper missed a function or Sber introduced
+        a feature without documenting it on /functions.  Known upstream typos
+        are allowlisted in :attr:`KNOWN_SBER_DOC_ISSUES`.
+        """
+        all_features: set[str] = set()
+        for schema in sber_schemas.values():
+            all_features.update(schema.get("features", []))
+        catalog_names = set(sber_functions.keys())
+        orphan = (all_features - catalog_names) - self.KNOWN_SBER_DOC_ISSUES
+        assert not orphan, f"Features referenced by categories but missing from /functions catalog: {orphan}"
+
+    def test_functions_cross_reference_matches_category_schemas(
+        self,
+        sber_schemas: dict[str, dict],
+        sber_functions: dict[str, dict],
+    ) -> None:
+        """Function.used_in_categories should mention every category that actually uses it.
+
+        Sanity check that Sber docs are internally consistent — if a function
+        says 'used in light' but light's schema doesn't list it, one of them
+        is wrong.  We only flag obvious mismatches (>0 declared but 0 actual
+        matches), not subset differences, to avoid false positives.
+        """
+        for name, spec in sber_functions.items():
+            declared = set(spec.get("used_in_categories", []))
+            if not declared:
+                continue
+            actual = {cat for cat, schema in sber_schemas.items() if name in schema.get("features", [])}
+            if not actual:
+                continue  # Sber docs sometimes list categories via inheritance
+            intersection = declared & actual
+            assert intersection, (
+                f"Function {name}: declared used in {declared} but not listed in any of their feature lists"
+            )

--- a/tools/fetch_sber_schemas.py
+++ b/tools/fetch_sber_schemas.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
 # ruff: noqa: T201  # CLI tool — print() is the intended interface
-"""Fetch canonical Sber device schemas from developers.sber.ru.
+"""Fetch canonical Sber device schemas + function catalog.
 
-The Sber C2C docs pages are client-side rendered (Next.js), so a plain
-HTTP GET returns an empty shell.  This script uses Playwright headless
-chromium to render each category page, extract the JSON <pre> block
-containing the canonical model schema, and write a single snapshot
-file that drives compliance tests.
+Renders every device category page and every function page on
+developers.sber.ru (client-side rendered via Next.js — plain HTTP
+returns an empty shell).  Builds two artifacts:
+
+1. ``tests/hacs/__snapshots__/sber_schemas.json`` — per-category
+   reference models (features, allowed_values, dependencies).
+2. ``tests/hacs/__snapshots__/sber_full_spec.json`` — unified
+   artifact containing every category + every function with type,
+   range, usage and cross-references between them.
 
 Usage:
     pip install playwright
     playwright install chromium
     python tools/fetch_sber_schemas.py
 
-Output:
-    tests/hacs/__snapshots__/sber_schemas.json
-
-CI runs this weekly.  Diff detection in ``sber-compliance`` workflow
-creates a PR when Sber documentation changes upstream.
+CI runs this weekly.  Diff detection in the ``sber-compliance``
+workflow creates a PR when the documentation changes upstream.
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 try:
@@ -33,6 +35,11 @@ try:
 except ImportError:
     print("ERROR: playwright not installed. Run: pip install playwright && playwright install chromium")
     sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 
 # All 28 Sber device categories (must match CATEGORY_REQUIRED_FEATURES
 # in custom_components/sber_mqtt_bridge/sber_models.py).
@@ -68,48 +75,80 @@ CATEGORIES: tuple[str, ...] = (
 )
 
 BASE_URL = "https://developers.sber.ru/docs/ru/smarthome/c2c"
-OUTPUT_FILE = Path(__file__).parent.parent / "tests" / "hacs" / "__snapshots__" / "sber_schemas.json"
+SCHEMAS_FILE = Path(__file__).parent.parent / "tests" / "hacs" / "__snapshots__" / "sber_schemas.json"
+FULL_SPEC_FILE = Path(__file__).parent.parent / "tests" / "hacs" / "__snapshots__" / "sber_full_spec.json"
+
+# Links on /functions to exclude (structural pages, not functions)
+_STRUCTURAL_LINKS = (
+    "types",
+    "structure",
+    "structures",
+    "cloud-to-cloud",
+    "api",
+    "allowed_values",
+    "dependencies",
+    "device",
+    "devices",
+    "model",
+    "state",
+    "value",
+    "overview",
+    "intro",
+    "functions",
+    "discovery",
+    "migration",
+    "auth",
+    "mqtt",
+    "rest",
+    "examples",
+    "faq",
+)
+
+# Function name regex in title: "Функция {name} | ..."
+_FUNC_TITLE_RE = re.compile(r"Функция\s+([a-z_0-9]+)")
+
+# Type declarations in function page text: "Тип данных: INTEGER(50,1000)" etc.
+_TYPE_DECL_RE = re.compile(
+    r"Тип данных:\s*([A-Z]+)(?:\s*\(([^)]+)\))?",
+    flags=re.IGNORECASE,
+)
+
+# Category listing marker on function page
+_CATEGORY_MARKER = "Устройства с этой функцией"
+
+# Trailing commas in Sber JSON examples (not valid JSON) — strip before parsing
+_TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
 
 
-def extract_schema_from_page(page, category: str) -> dict | None:
-    """Render the category page, find the <pre> block matching ``category``.
+# ---------------------------------------------------------------------------
+# Category schema extraction
+# ---------------------------------------------------------------------------
 
-    The docs pages have multiple <pre> blocks (model example, user device
-    example, individual field examples).  We pick the one that parses as
-    JSON AND has ``category == <expected>``.
-    """
-    url = f"{BASE_URL}/{category}"
+
+def _load_page(page, url: str) -> bool:
+    """Navigate + wait for content.  Return True on success."""
     try:
         page.goto(url, wait_until="domcontentloaded", timeout=20_000)
-        page.wait_for_selector("pre", timeout=10_000)
+        page.wait_for_selector("pre, article", timeout=10_000)
     except PlaywrightTimeout:
+        return False
+    return True
+
+
+def _parse_json_block(text: str) -> dict | None:
+    """Parse a <pre> block that should be a JSON object (lenient)."""
+    text = text.strip()
+    if not text.startswith("{"):
+        return None
+    cleaned = _TRAILING_COMMA_RE.sub(r"\1", text)
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
         return None
 
-    pre_blocks: list[str] = page.eval_on_selector_all("pre", "els => els.map(e => e.innerText)")
 
-    for block in pre_blocks:
-        text = block.strip()
-        if not text.startswith("{"):
-            continue
-        # Sber docs sometimes include trailing commas which are invalid
-        # JSON. Strip them before parsing.
-        cleaned = re.sub(r",(\s*[}\]])", r"\1", text)
-        try:
-            data = json.loads(cleaned)
-        except json.JSONDecodeError:
-            continue
-        if data.get("category") == category:
-            return _normalize_schema(data)
-    return None
-
-
-def _normalize_schema(raw: dict) -> dict:
-    """Strip instance-specific fields so only the schema shape remains.
-
-    The Sber docs example models include fictional ``id``, ``manufacturer``,
-    ``model``, version strings that are not part of the schema contract.
-    We only care about: category, features, allowed_values, dependencies.
-    """
+def _normalize_category_schema(raw: dict) -> dict:
+    """Strip instance-specific fields — keep only schema contract."""
     return {
         "category": raw.get("category"),
         "features": sorted(raw.get("features", [])),
@@ -118,10 +157,118 @@ def _normalize_schema(raw: dict) -> dict:
     }
 
 
+def extract_category_schema(page, category: str) -> dict | None:
+    """Render a category page, pick the <pre> whose JSON category matches."""
+    if not _load_page(page, f"{BASE_URL}/{category}"):
+        return None
+    pre_blocks: list[str] = page.eval_on_selector_all("pre", "els => els.map(e => e.innerText)")
+    for block in pre_blocks:
+        data = _parse_json_block(block)
+        if data and data.get("category") == category:
+            return _normalize_category_schema(data)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Function catalog extraction
+# ---------------------------------------------------------------------------
+
+
+def list_function_slugs(page) -> list[str]:
+    """Get the list of function page slugs from /functions index."""
+    if not _load_page(page, f"{BASE_URL}/functions"):
+        return []
+    hrefs: list[str] = page.eval_on_selector_all(
+        'a[href*="/smarthome/c2c/"]',
+        "els => els.map(a => a.getAttribute('href'))",
+    )
+    slugs: set[str] = set()
+    prefix = "/docs/ru/smarthome/c2c/"
+    for href in hrefs:
+        if not href or not href.startswith(prefix):
+            continue
+        slug = href[len(prefix) :].strip("/")
+        if not slug or slug in _STRUCTURAL_LINKS:
+            continue
+        if slug in CATEGORIES:
+            continue  # Category pages, not function pages
+        slugs.add(slug)
+    return sorted(slugs)
+
+
+def extract_function_spec(page, slug: str) -> dict | None:
+    """Parse a single function page — type, range, usage, categories."""
+    if not _load_page(page, f"{BASE_URL}/{slug}"):
+        return None
+
+    title = page.title()
+    name_match = _FUNC_TITLE_RE.search(title)
+    # URL slugs sometimes use dashes; the canonical function name uses underscores.
+    name = name_match.group(1) if name_match else slug.replace("-", "_")
+
+    article_text: str = page.eval_on_selector(
+        "article, main",
+        "el => el ? el.innerText : ''",
+    )
+
+    type_match = _TYPE_DECL_RE.search(article_text)
+    type_name: str | None = None
+    range_str: str | None = None
+    if type_match:
+        type_name = type_match.group(1).upper()
+        range_str = (type_match.group(2) or "").strip() or None
+
+    categories_used = _parse_categories_from_text(article_text)
+
+    pre_blocks: list[str] = page.eval_on_selector_all("pre", "els => els.map(e => e.innerText)")
+
+    return {
+        "name": name,
+        "type": type_name,
+        "range": range_str,
+        "used_in_categories": sorted(categories_used),
+        "examples": [b.strip() for b in pre_blocks if b.strip()],
+    }
+
+
+def _parse_categories_from_text(text: str) -> set[str]:
+    """Extract category names from the 'Устройства с этой функцией' section."""
+    idx = text.find(_CATEGORY_MARKER)
+    if idx == -1:
+        return set()
+    tail = text[idx + len(_CATEGORY_MARKER) :]
+    # Next section is usually "Примеры голосовых команд"
+    end = tail.find("Примеры")
+    if end != -1:
+        tail = tail[:end]
+    mentioned: set[str] = set()
+    for cat in CATEGORIES:
+        pattern = rf"\b{re.escape(cat)}\b"
+        if re.search(pattern, tail):
+            mentioned.add(cat)
+    return mentioned
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
 def main() -> int:
-    """Fetch schemas for all categories and write the snapshot file."""
-    schemas: dict[str, dict | None] = {}
-    failed: list[str] = []
+    """Fetch all categories + functions, write two snapshots."""
+    categories: dict[str, dict] = {}
+    category_failures: list[str] = []
+
+    functions: dict[str, dict] = {}
+    function_failures: list[str] = []
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
@@ -132,30 +279,57 @@ def main() -> int:
         )
         page = context.new_page()
 
+        # Phase 1: category schemas
+        print(f"=== Phase 1: {len(CATEGORIES)} category schemas ===")
         for idx, category in enumerate(CATEGORIES, start=1):
-            print(f"[{idx:2d}/{len(CATEGORIES)}] Fetching {category}...", end=" ", flush=True)
-            schema = extract_schema_from_page(page, category)
+            print(f"[{idx:2d}/{len(CATEGORIES)}] Fetching category {category}...", end=" ", flush=True)
+            schema = extract_category_schema(page, category)
             if schema is None:
                 print("MISSING")
-                failed.append(category)
+                category_failures.append(category)
             else:
-                features_count = len(schema["features"])
-                av_count = len(schema["allowed_values"])
-                print(f"OK ({features_count} features, {av_count} allowed_values)")
-                schemas[category] = schema
+                print(f"OK ({len(schema['features'])} features)")
+                categories[category] = schema
+
+        # Phase 2: function catalog
+        print("\n=== Phase 2: function catalog ===")
+        function_slugs = list_function_slugs(page)
+        print(f"Discovered {len(function_slugs)} function pages")
+        for idx, slug in enumerate(function_slugs, start=1):
+            print(f"[{idx:3d}/{len(function_slugs)}] Fetching function {slug}...", end=" ", flush=True)
+            spec = extract_function_spec(page, slug)
+            if spec is None or spec.get("type") is None:
+                print("MISSING")
+                function_failures.append(slug)
+                continue
+            name = spec["name"]
+            # Drop oversized example list from functions snapshot
+            spec = {k: v for k, v in spec.items() if k != "examples"}
+            functions[name] = spec
+            print(f"OK ({spec['type']})")
 
         browser.close()
 
-    # Deterministic output — sorted keys, stable indentation
-    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT_FILE.write_text(
-        json.dumps(schemas, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    print(f"\nWrote {len(schemas)} schemas to {OUTPUT_FILE}")
+    # Write per-category snapshot (backward-compatible with existing tests)
+    _write_json(SCHEMAS_FILE, categories)
+    print(f"\nWrote {len(categories)} category schemas to {SCHEMAS_FILE}")
 
-    if failed:
-        print(f"Failed to fetch: {', '.join(failed)}")
+    # Write unified full spec
+    full_spec = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "source": BASE_URL,
+        "categories": categories,
+        "functions": functions,
+    }
+    _write_json(FULL_SPEC_FILE, full_spec)
+    print(f"Wrote unified spec ({len(categories)} categories, {len(functions)} functions) to {FULL_SPEC_FILE}")
+
+    if category_failures or function_failures:
+        print()
+        if category_failures:
+            print(f"Failed categories ({len(category_failures)}): {', '.join(category_failures)}")
+        if function_failures:
+            print(f"Failed functions ({len(function_failures)}): {', '.join(function_failures[:10])}...")
         return 1
     return 0
 


### PR DESCRIPTION
## Summary

Extends scraper to fetch the complete Sber C2C device tree into a single artifact.

### New artifact
`tests/hacs/__snapshots__/sber_full_spec.json`:
- 28 categories (features, allowed_values, dependencies)
- **90 functions** with type, range, and cross-references to categories
- Generated timestamp + source URL

### Real upstream issues found
- `battery_percentag` — typo in scenario_button reference (missing 'e')
- `sleep_timer` — used in led_strip but no /functions page

Both documented in `KNOWN_SBER_DOC_ISSUES` allowlist.

### Tests
1690/1690 pass (+5 new compliance checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)