### PR TITLE
feat: extract Sber obligatory features (✔︎ markers) as 3rd compliance layer

### DIFF
--- a/custom_components/sber_mqtt_bridge/_generated/__init__.py
+++ b/custom_components/sber_mqtt_bridge/_generated/__init__.py
@@ -5,15 +5,17 @@ DO NOT EDIT BY HAND.  Regenerate with:
     python tools/codegen.py
 
 Source: https://developers.sber.ru/docs/ru/smarthome/c2c
-Spec generated at: 2026-04-12T21:05:04.890060+00:00
+Spec generated at: 2026-04-12T21:42:23.056807+00:00
 """
 
 from __future__ import annotations
 
 from .category_features import CATEGORY_REFERENCE_FEATURES
 from .feature_types import FEATURE_TYPES
+from .obligatory_features import CATEGORY_OBLIGATORY_FEATURES
 
 __all__ = [
+    "CATEGORY_OBLIGATORY_FEATURES",
     "CATEGORY_REFERENCE_FEATURES",
     "FEATURE_TYPES",
     "SPEC_GENERATED_AT",
@@ -23,5 +25,5 @@ __all__ = [
 SPEC_SOURCE: str = "https://developers.sber.ru/docs/ru/smarthome/c2c"
 """Upstream documentation URL used to generate this package."""
 
-SPEC_GENERATED_AT: str = "2026-04-12T21:05:04.890060+00:00"
+SPEC_GENERATED_AT: str = "2026-04-12T21:42:23.056807+00:00"
 """ISO 8601 timestamp when the spec snapshot was fetched."""

--- a/custom_components/sber_mqtt_bridge/_generated/category_features.py
+++ b/custom_components/sber_mqtt_bridge/_generated/category_features.py
@@ -5,7 +5,7 @@ DO NOT EDIT BY HAND.  Regenerate with:
     python tools/codegen.py
 
 Source: https://developers.sber.ru/docs/ru/smarthome/c2c
-Spec generated at: 2026-04-12T21:05:04.890060+00:00
+Spec generated at: 2026-04-12T21:42:23.056807+00:00
 """
 
 from __future__ import annotations
@@ -17,6 +17,9 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
             "battery_percentage",
             "online",
             "open_left_percentage",
+            "open_left_set",
+            "open_left_state",
+            "open_percentage",
             "open_rate",
             "open_right_percentage",
             "open_right_set",
@@ -32,6 +35,7 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
             "open_left_percentage",
             "open_left_set",
             "open_left_state",
+            "open_percentage",
             "open_rate",
             "open_right_percentage",
             "open_right_set",
@@ -44,20 +48,24 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
     "hub": frozenset({"online"}),
     "hvac_ac": frozenset(
         {
+            "humidity",
             "hvac_air_flow_direction",
             "hvac_air_flow_power",
             "hvac_humidity_set",
+            "hvac_ionization",
             "hvac_night_mode",
             "hvac_temp_set",
             "hvac_work_mode",
             "on_off",
             "online",
+            "temperature",
         }
     ),
     "hvac_air_purifier": frozenset(
         {
             "hvac_air_flow_power",
             "hvac_aromatization",
+            "hvac_decontaminate",
             "hvac_ionization",
             "hvac_night_mode",
             "hvac_replace_filter",
@@ -66,8 +74,10 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
             "online",
         }
     ),
-    "hvac_boiler": frozenset({"hvac_temp_set", "hvac_thermostat_mode", "on_off", "online", "temperature"}),
-    "hvac_fan": frozenset({"hvac_air_flow_power", "on_off", "online"}),
+    "hvac_boiler": frozenset(
+        {"hvac_heating_rate", "hvac_temp_set", "hvac_thermostat_mode", "on_off", "online", "temperature"}
+    ),
+    "hvac_fan": frozenset({"hvac_air_flow_power", "hvac_direction_set", "on_off", "online"}),
     "hvac_heater": frozenset(
         {"hvac_air_flow_power", "hvac_temp_set", "hvac_thermostat_mode", "on_off", "online", "temperature"}
     ),
@@ -80,6 +90,7 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
             "hvac_night_mode",
             "hvac_replace_filter",
             "hvac_replace_ionizator",
+            "hvac_water_level",
             "hvac_water_low_level",
             "hvac_water_percentage",
             "on_off",
@@ -87,7 +98,9 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
         }
     ),
     "hvac_radiator": frozenset({"hvac_temp_set", "on_off", "online", "temperature"}),
-    "hvac_underfloor_heating": frozenset({"hvac_temp_set", "hvac_thermostat_mode", "on_off", "online", "temperature"}),
+    "hvac_underfloor_heating": frozenset(
+        {"hvac_heating_rate", "hvac_temp_set", "hvac_thermostat_mode", "on_off", "online", "temperature"}
+    ),
     "intercom": frozenset({"incoming_call", "online", "reject_call", "unlock"}),
     "kettle": frozenset(
         {
@@ -100,13 +113,33 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
             "online",
         }
     ),
-    "led_strip": frozenset(
-        {"light_brightness", "light_colour", "light_colour_temp", "light_mode", "on_off", "online", "sleep_timer"}
-    ),
+    "led_strip": frozenset({"light_brightness", "light_colour", "light_colour_temp", "light_mode", "on_off", "online"}),
     "light": frozenset({"light_brightness", "light_colour", "light_colour_temp", "light_mode", "on_off", "online"}),
     "relay": frozenset({"current", "on_off", "online", "power", "voltage"}),
     "scenario_button": frozenset(
-        {"battery_percentag", "button_1_event", "button_2_event", "online", "signal_strength"}
+        {
+            "battery_low_power",
+            "battery_percentage",
+            "button_10_event",
+            "button_1_event",
+            "button_2_event",
+            "button_3_event",
+            "button_4_event",
+            "button_5_event",
+            "button_6_event",
+            "button_7_event",
+            "button_8_event",
+            "button_9_event",
+            "button_bottom_left_event",
+            "button_bottom_right_event",
+            "button_event",
+            "button_left_event",
+            "button_right_event",
+            "button_top_left_event",
+            "button_top_right_event",
+            "online",
+            "signal_strength",
+        }
     ),
     "sensor_door": frozenset(
         {
@@ -180,12 +213,21 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
         }
     ),
     "valve": frozenset(
-        {"battery_low_power", "battery_percentage", "online", "open_set", "open_state", "signal_strength"}
+        {
+            "battery_low_power",
+            "battery_percentage",
+            "online",
+            "open_percentage",
+            "open_set",
+            "open_state",
+            "signal_strength",
+        }
     ),
     "window_blind": frozenset(
         {
             "battery_low_power",
             "battery_percentage",
+            "light_transmission_percentage",
             "online",
             "open_percentage",
             "open_rate",
@@ -195,9 +237,10 @@ CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {
         }
     ),
 }
-"""All features listed in the Sber reference model for each category.
+"""All features declared for each category in Sber docs.
 
-This is the *widest* known-valid feature set per category.  Use for
-compliance checks: features we emit outside this set are unknown to
-Sber cloud and likely cause silent rejection (see the TV allowed_values
-bug that motivated this module)."""
+Source: the "Доступные функции устройства" table on each category
+page plus the reference JSON example.  Use as the *widest* known-valid
+feature set per category — features we emit outside this set are
+unknown to Sber cloud and likely cause silent rejection (see the
+TV ``allowed_values`` bug that motivated this module)."""

--- a/custom_components/sber_mqtt_bridge/_generated/feature_types.py
+++ b/custom_components/sber_mqtt_bridge/_generated/feature_types.py
@@ -5,7 +5,7 @@ DO NOT EDIT BY HAND.  Regenerate with:
     python tools/codegen.py
 
 Source: https://developers.sber.ru/docs/ru/smarthome/c2c
-Spec generated at: 2026-04-12T21:05:04.890060+00:00
+Spec generated at: 2026-04-12T21:42:23.056807+00:00
 """
 
 from __future__ import annotations

--- a/custom_components/sber_mqtt_bridge/_generated/obligatory_features.py
+++ b/custom_components/sber_mqtt_bridge/_generated/obligatory_features.py
@@ -1,0 +1,48 @@
+"""AUTO-GENERATED from tests/hacs/__snapshots__/sber_full_spec.json.
+
+DO NOT EDIT BY HAND.  Regenerate with:
+
+    python tools/codegen.py
+
+Source: https://developers.sber.ru/docs/ru/smarthome/c2c
+Spec generated at: 2026-04-12T21:42:23.056807+00:00
+"""
+
+from __future__ import annotations
+
+CATEGORY_OBLIGATORY_FEATURES: dict[str, frozenset[str]] = {
+    "curtain": frozenset({"online", "open_percentage", "open_set", "open_state"}),
+    "gate": frozenset({"online", "open_percentage", "open_set", "open_state"}),
+    "hub": frozenset({"online"}),
+    "hvac_ac": frozenset({"hvac_temp_set", "on_off", "online"}),
+    "hvac_air_purifier": frozenset({"on_off", "online"}),
+    "hvac_boiler": frozenset({"on_off", "online"}),
+    "hvac_fan": frozenset({"on_off", "online"}),
+    "hvac_heater": frozenset({"on_off", "online"}),
+    "hvac_humidifier": frozenset({"on_off", "online"}),
+    "hvac_radiator": frozenset({"on_off", "online"}),
+    "hvac_underfloor_heating": frozenset({"on_off", "online"}),
+    "intercom": frozenset({"online"}),
+    "kettle": frozenset({"on_off", "online"}),
+    "led_strip": frozenset({"on_off", "online"}),
+    "light": frozenset({"on_off", "online"}),
+    "relay": frozenset({"on_off", "online"}),
+    "scenario_button": frozenset({"online"}),
+    "sensor_door": frozenset({"doorcontact_state", "online"}),
+    "sensor_gas": frozenset({"gas_leak_state", "online"}),
+    "sensor_pir": frozenset({"online", "pir"}),
+    "sensor_smoke": frozenset({"online", "smoke_state"}),
+    "sensor_temp": frozenset({"humidity", "online", "temperature"}),
+    "sensor_water_leak": frozenset({"online", "water_leak_state"}),
+    "socket": frozenset({"on_off", "online"}),
+    "tv": frozenset({"on_off", "online"}),
+    "vacuum_cleaner": frozenset({"online"}),
+    "valve": frozenset({"online", "open_percentage", "open_set", "open_state"}),
+    "window_blind": frozenset({"online", "open_percentage", "open_set", "open_state"}),
+}
+"""Features marked obligatory (``✔︎``) in Sber docs per category.
+
+Extracted from the "Доступные функции устройства" table on each
+category page.  These are the features every device of this category
+MUST emit to be accepted by Sber cloud — emitting fewer is a likely
+cause of silent rejection."""

--- a/custom_components/sber_mqtt_bridge/sber_models.py
+++ b/custom_components/sber_mqtt_bridge/sber_models.py
@@ -23,7 +23,11 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
-from ._generated import CATEGORY_REFERENCE_FEATURES, FEATURE_TYPES
+from ._generated import (
+    CATEGORY_OBLIGATORY_FEATURES,
+    CATEGORY_REFERENCE_FEATURES,
+    FEATURE_TYPES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -462,6 +466,27 @@ CATEGORY_REQUIRED_FEATURES: dict[str, frozenset[str]] = {
     "hub": frozenset({"online"}),
 }
 """Required features per Sber category, verified via Context7."""
+
+
+def missing_obligatory_features(category: str, features: set[str]) -> set[str]:
+    """Return obligatory features missing from the emitted set.
+
+    Uses :data:`CATEGORY_OBLIGATORY_FEATURES` (auto-generated from Sber
+    docs ``✔︎`` markers).  Missing obligatory features are a likely
+    cause of silent device rejection by Sber cloud.
+
+    Args:
+        category: Sber category slug.
+        features: Features our device would emit.
+
+    Returns:
+        Set of obligatory features absent from ``features``.  Empty set
+        for unknown categories (fail-open — we don't block unknown cats).
+    """
+    obligatory = CATEGORY_OBLIGATORY_FEATURES.get(category)
+    if obligatory is None:
+        return set()
+    return obligatory - set(features)
 
 
 def unknown_features_for_category(category: str, features: set[str]) -> set[str]:

--- a/tests/hacs/__snapshots__/sber_full_spec.json
+++ b/tests/hacs/__snapshots__/sber_full_spec.json
@@ -1,6 +1,22 @@
 {
   "categories": {
     "curtain": {
+      "all_features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "open_left_percentage",
+        "open_left_set",
+        "open_left_state",
+        "open_percentage",
+        "open_rate",
+        "open_right_percentage",
+        "open_right_set",
+        "open_right_state",
+        "open_set",
+        "open_state",
+        "signal_strength"
+      ],
       "allowed_values": {
         "open_rate": {
           "enum_values": {
@@ -27,9 +43,29 @@
         "open_set",
         "open_state",
         "signal_strength"
+      ],
+      "obligatory": [
+        "online",
+        "open_percentage",
+        "open_set",
+        "open_state"
       ]
     },
     "gate": {
+      "all_features": [
+        "online",
+        "open_left_percentage",
+        "open_left_set",
+        "open_left_state",
+        "open_percentage",
+        "open_rate",
+        "open_right_percentage",
+        "open_right_set",
+        "open_right_state",
+        "open_set",
+        "open_state",
+        "signal_strength"
+      ],
       "allowed_values": {
         "open_rate": {
           "enum_values": {
@@ -56,17 +92,42 @@
         "open_set",
         "open_state",
         "signal_strength"
+      ],
+      "obligatory": [
+        "online",
+        "open_percentage",
+        "open_set",
+        "open_state"
       ]
     },
     "hub": {
+      "all_features": [
+        "online"
+      ],
       "allowed_values": {},
       "category": "hub",
       "dependencies": {},
       "features": [
         "online"
+      ],
+      "obligatory": [
+        "online"
       ]
     },
     "hvac_ac": {
+      "all_features": [
+        "humidity",
+        "hvac_air_flow_direction",
+        "hvac_air_flow_power",
+        "hvac_humidity_set",
+        "hvac_ionization",
+        "hvac_night_mode",
+        "hvac_temp_set",
+        "hvac_work_mode",
+        "on_off",
+        "online",
+        "temperature"
+      ],
       "allowed_values": {
         "hvac_air_flow_power": {
           "enum_values": {
@@ -92,9 +153,25 @@
         "hvac_work_mode",
         "on_off",
         "online"
+      ],
+      "obligatory": [
+        "hvac_temp_set",
+        "on_off",
+        "online"
       ]
     },
     "hvac_air_purifier": {
+      "all_features": [
+        "hvac_air_flow_power",
+        "hvac_aromatization",
+        "hvac_decontaminate",
+        "hvac_ionization",
+        "hvac_night_mode",
+        "hvac_replace_filter",
+        "hvac_replace_ionizator",
+        "on_off",
+        "online"
+      ],
       "allowed_values": {
         "hvac_air_flow_power": {
           "enum_values": {
@@ -120,9 +197,21 @@
         "hvac_replace_ionizator",
         "on_off",
         "online"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "hvac_boiler": {
+      "all_features": [
+        "hvac_heating_rate",
+        "hvac_temp_set",
+        "hvac_thermostat_mode",
+        "on_off",
+        "online",
+        "temperature"
+      ],
       "allowed_values": {
         "hvac_temp_set": {
           "integer_values": {
@@ -141,9 +230,19 @@
         "on_off",
         "online",
         "temperature"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "hvac_fan": {
+      "all_features": [
+        "hvac_air_flow_power",
+        "hvac_direction_set",
+        "on_off",
+        "online"
+      ],
       "allowed_values": {
         "hvac_air_flow_power": {
           "enum_values": {
@@ -164,9 +263,21 @@
         "hvac_air_flow_power",
         "on_off",
         "online"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "hvac_heater": {
+      "all_features": [
+        "hvac_air_flow_power",
+        "hvac_temp_set",
+        "hvac_thermostat_mode",
+        "on_off",
+        "online",
+        "temperature"
+      ],
       "allowed_values": {
         "hvac_air_flow_power": {
           "enum_values": {
@@ -190,9 +301,27 @@
         "on_off",
         "online",
         "temperature"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "hvac_humidifier": {
+      "all_features": [
+        "humidity",
+        "hvac_air_flow_power",
+        "hvac_humidity_set",
+        "hvac_ionization",
+        "hvac_night_mode",
+        "hvac_replace_filter",
+        "hvac_replace_ionizator",
+        "hvac_water_level",
+        "hvac_water_low_level",
+        "hvac_water_percentage",
+        "on_off",
+        "online"
+      ],
       "allowed_values": {
         "hvac_air_flow_power": {
           "enum_values": {
@@ -221,9 +350,19 @@
         "hvac_water_percentage",
         "on_off",
         "online"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "hvac_radiator": {
+      "all_features": [
+        "hvac_temp_set",
+        "on_off",
+        "online",
+        "temperature"
+      ],
       "allowed_values": {
         "hvac_temp_set": {
           "integer_values": {
@@ -241,9 +380,21 @@
         "on_off",
         "online",
         "temperature"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "hvac_underfloor_heating": {
+      "all_features": [
+        "hvac_heating_rate",
+        "hvac_temp_set",
+        "hvac_thermostat_mode",
+        "on_off",
+        "online",
+        "temperature"
+      ],
       "allowed_values": {
         "hvac_temp_set": {
           "integer_values": {
@@ -262,9 +413,19 @@
         "on_off",
         "online",
         "temperature"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "intercom": {
+      "all_features": [
+        "incoming_call",
+        "online",
+        "reject_call",
+        "unlock"
+      ],
       "allowed_values": {},
       "category": "intercom",
       "dependencies": {},
@@ -273,9 +434,21 @@
         "online",
         "reject_call",
         "unlock"
+      ],
+      "obligatory": [
+        "online"
       ]
     },
     "kettle": {
+      "all_features": [
+        "child_lock",
+        "kitchen_water_level",
+        "kitchen_water_low_level",
+        "kitchen_water_temperature",
+        "kitchen_water_temperature_set",
+        "on_off",
+        "online"
+      ],
       "allowed_values": {
         "kitchen_water_temperature_set": {
           "integer_values": {
@@ -296,9 +469,21 @@
         "kitchen_water_temperature_set",
         "on_off",
         "online"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "led_strip": {
+      "all_features": [
+        "light_brightness",
+        "light_colour",
+        "light_colour_temp",
+        "light_mode",
+        "on_off",
+        "online"
+      ],
       "allowed_values": {
         "light_brightness": {
           "integer_values": {
@@ -319,9 +504,21 @@
         "on_off",
         "online",
         "sleep_timer"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "light": {
+      "all_features": [
+        "light_brightness",
+        "light_colour",
+        "light_colour_temp",
+        "light_mode",
+        "on_off",
+        "online"
+      ],
       "allowed_values": {
         "light_brightness": {
           "integer_values": {
@@ -341,9 +538,20 @@
         "light_mode",
         "on_off",
         "online"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "relay": {
+      "all_features": [
+        "current",
+        "on_off",
+        "online",
+        "power",
+        "voltage"
+      ],
       "allowed_values": {
         "power": {
           "integer_values": {
@@ -362,9 +570,36 @@
         "online",
         "power",
         "voltage"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "scenario_button": {
+      "all_features": [
+        "battery_low_power",
+        "battery_percentage",
+        "button_10_event",
+        "button_1_event",
+        "button_2_event",
+        "button_3_event",
+        "button_4_event",
+        "button_5_event",
+        "button_6_event",
+        "button_7_event",
+        "button_8_event",
+        "button_9_event",
+        "button_bottom_left_event",
+        "button_bottom_right_event",
+        "button_event",
+        "button_left_event",
+        "button_right_event",
+        "button_top_left_event",
+        "button_top_right_event",
+        "online",
+        "signal_strength"
+      ],
       "allowed_values": {
         "button_1_event": {
           "enum_values": {
@@ -384,9 +619,21 @@
         "button_2_event",
         "online",
         "signal_strength"
+      ],
+      "obligatory": [
+        "online"
       ]
     },
     "sensor_door": {
+      "all_features": [
+        "battery_low_power",
+        "battery_percentage",
+        "doorcontact_state",
+        "online",
+        "sensor_sensitive",
+        "signal_strength",
+        "tamper_alarm"
+      ],
       "allowed_values": {
         "sensor_sensitive": {
           "enum_values": {
@@ -408,9 +655,22 @@
         "sensor_sensitive",
         "signal_strength",
         "tamper_alarm"
+      ],
+      "obligatory": [
+        "doorcontact_state",
+        "online"
       ]
     },
     "sensor_gas": {
+      "all_features": [
+        "alarm_mute",
+        "battery_low_power",
+        "battery_percentage",
+        "gas_leak_state",
+        "online",
+        "sensor_sensitive",
+        "signal_strength"
+      ],
       "allowed_values": {
         "signal_strength": {
           "enum_values": {
@@ -432,9 +692,21 @@
         "online",
         "sensor_sensitive",
         "signal_strength"
+      ],
+      "obligatory": [
+        "gas_leak_state",
+        "online"
       ]
     },
     "sensor_pir": {
+      "all_features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "pir",
+        "sensor_sensitive",
+        "signal_strength"
+      ],
       "allowed_values": {
         "sensor_sensitive": {
           "enum_values": {
@@ -455,9 +727,21 @@
         "pir",
         "sensor_sensitive",
         "signal_strength"
+      ],
+      "obligatory": [
+        "online",
+        "pir"
       ]
     },
     "sensor_smoke": {
+      "all_features": [
+        "alarm_mute",
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "signal_strength",
+        "smoke_state"
+      ],
       "allowed_values": {
         "signal_strength": {
           "enum_values": {
@@ -478,9 +762,24 @@
         "online",
         "signal_strength",
         "smoke_state"
+      ],
+      "obligatory": [
+        "online",
+        "smoke_state"
       ]
     },
     "sensor_temp": {
+      "all_features": [
+        "air_pressure",
+        "battery_low_power",
+        "battery_percentage",
+        "humidity",
+        "online",
+        "sensor_sensitive",
+        "signal_strength",
+        "temp_unit_view",
+        "temperature"
+      ],
       "allowed_values": {
         "sensor_sensitive": {
           "enum_values": {
@@ -504,9 +803,21 @@
         "signal_strength",
         "temp_unit_view",
         "temperature"
+      ],
+      "obligatory": [
+        "humidity",
+        "online",
+        "temperature"
       ]
     },
     "sensor_water_leak": {
+      "all_features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "signal_strength",
+        "water_leak_state"
+      ],
       "allowed_values": {
         "signal_strength": {
           "enum_values": {
@@ -526,9 +837,21 @@
         "online",
         "signal_strength",
         "water_leak_state"
+      ],
+      "obligatory": [
+        "online",
+        "water_leak_state"
       ]
     },
     "socket": {
+      "all_features": [
+        "child_lock",
+        "current",
+        "on_off",
+        "online",
+        "power",
+        "voltage"
+      ],
       "allowed_values": {
         "power": {
           "integer_values": {
@@ -548,9 +871,26 @@
         "online",
         "power",
         "voltage"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "tv": {
+      "all_features": [
+        "channel",
+        "channel_int",
+        "custom_key",
+        "direction",
+        "mute",
+        "number",
+        "on_off",
+        "online",
+        "source",
+        "volume",
+        "volume_int"
+      ],
       "allowed_values": {
         "source": {
           "enum_values": {
@@ -582,9 +922,22 @@
         "source",
         "volume",
         "volume_int"
+      ],
+      "obligatory": [
+        "on_off",
+        "online"
       ]
     },
     "vacuum_cleaner": {
+      "all_features": [
+        "battery_percentage",
+        "child_lock",
+        "online",
+        "vacuum_cleaner_cleaning_type",
+        "vacuum_cleaner_command",
+        "vacuum_cleaner_program",
+        "vacuum_cleaner_status"
+      ],
       "allowed_values": {
         "vacuum_cleaner_program": {
           "enum_values": {
@@ -607,9 +960,21 @@
         "vacuum_cleaner_command",
         "vacuum_cleaner_program",
         "vacuum_cleaner_status"
+      ],
+      "obligatory": [
+        "online"
       ]
     },
     "valve": {
+      "all_features": [
+        "battery_low_power",
+        "battery_percentage",
+        "online",
+        "open_percentage",
+        "open_set",
+        "open_state",
+        "signal_strength"
+      ],
       "allowed_values": {
         "signal_strength": {
           "enum_values": {
@@ -630,9 +995,26 @@
         "open_set",
         "open_state",
         "signal_strength"
+      ],
+      "obligatory": [
+        "online",
+        "open_percentage",
+        "open_set",
+        "open_state"
       ]
     },
     "window_blind": {
+      "all_features": [
+        "battery_low_power",
+        "battery_percentage",
+        "light_transmission_percentage",
+        "online",
+        "open_percentage",
+        "open_rate",
+        "open_set",
+        "open_state",
+        "signal_strength"
+      ],
       "allowed_values": {
         "open_rate": {
           "enum_values": {
@@ -656,6 +1038,12 @@
         "open_set",
         "open_state",
         "signal_strength"
+      ],
+      "obligatory": [
+        "online",
+        "open_percentage",
+        "open_set",
+        "open_state"
       ]
     }
   },
@@ -763,7 +1151,9 @@
       "name": "button_6_event",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": []
+      "used_in_categories": [
+        "scenario_button"
+      ]
     },
     "button_7_event": {
       "name": "button_7_event",
@@ -799,31 +1189,27 @@
       "name": "button_bottom_right_event",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": [
-        "scenario_button"
-      ]
+      "used_in_categories": []
     },
     "button_event": {
       "name": "button_event",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": [
-        "scenario_button"
-      ]
+      "used_in_categories": []
     },
     "button_left_event": {
       "name": "button_left_event",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": []
+      "used_in_categories": [
+        "scenario_button"
+      ]
     },
     "button_right_event": {
       "name": "button_right_event",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": [
-        "scenario_button"
-      ]
+      "used_in_categories": []
     },
     "button_top_left_event": {
       "name": "button_top_left_event",
@@ -845,15 +1231,15 @@
       "name": "channel",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": [
-        "tv"
-      ]
+      "used_in_categories": []
     },
     "channel_int": {
       "name": "channel_int",
       "range": "0, 999",
       "type": "INTEGER",
-      "used_in_categories": []
+      "used_in_categories": [
+        "tv"
+      ]
     },
     "child_lock": {
       "name": "child_lock",
@@ -869,7 +1255,10 @@
       "name": "current",
       "range": "0, 30000",
       "type": "INTEGER",
-      "used_in_categories": []
+      "used_in_categories": [
+        "relay",
+        "socket"
+      ]
     },
     "custom_key": {
       "name": "custom_key",
@@ -899,9 +1288,7 @@
       "name": "gas_leak_state",
       "range": null,
       "type": "BOOL",
-      "used_in_categories": [
-        "sensor_gas"
-      ]
+      "used_in_categories": []
     },
     "humidity": {
       "name": "humidity",
@@ -937,7 +1324,9 @@
       "name": "hvac_aromatization",
       "range": null,
       "type": "BOOL",
-      "used_in_categories": []
+      "used_in_categories": [
+        "hvac_air_purifier"
+      ]
     },
     "hvac_decontaminate": {
       "name": "hvac_decontaminate",
@@ -951,7 +1340,9 @@
       "name": "hvac_direction_set",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": []
+      "used_in_categories": [
+        "hvac_fan"
+      ]
     },
     "hvac_heating_rate": {
       "name": "hvac_heating_rate",
@@ -1013,33 +1404,31 @@
       "name": "hvac_temp_set",
       "range": "5, 50",
       "type": "INTEGER",
-      "used_in_categories": [
-        "hvac_ac",
-        "hvac_boiler",
-        "hvac_heater",
-        "hvac_radiator",
-        "hvac_underfloor_heating"
-      ]
+      "used_in_categories": []
     },
     "hvac_thermostat_mode": {
       "name": "hvac_thermostat_mode",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": []
+      "used_in_categories": [
+        "hvac_boiler",
+        "hvac_heater",
+        "hvac_underfloor_heating"
+      ]
     },
     "hvac_water_level": {
       "name": "hvac_water_level",
       "range": "0, 50",
       "type": "FLOAT",
-      "used_in_categories": []
+      "used_in_categories": [
+        "hvac_humidifier"
+      ]
     },
     "hvac_water_low_level": {
       "name": "hvac_water_low_level",
       "range": null,
       "type": "BOOL",
-      "used_in_categories": [
-        "hvac_humidifier"
-      ]
+      "used_in_categories": []
     },
     "hvac_water_percentage": {
       "name": "hvac_water_percentage",
@@ -1083,7 +1472,9 @@
       "name": "kitchen_water_temperature",
       "range": "0, 100",
       "type": "INTEGER",
-      "used_in_categories": []
+      "used_in_categories": [
+        "kettle"
+      ]
     },
     "kitchen_water_temperature_set": {
       "name": "kitchen_water_temperature_set",
@@ -1097,10 +1488,7 @@
       "name": "light_brightness",
       "range": "50,1000",
       "type": "INTEGER",
-      "used_in_categories": [
-        "led_strip",
-        "light"
-      ]
+      "used_in_categories": []
     },
     "light_colour": {
       "name": "light_colour",
@@ -1157,19 +1545,7 @@
       "name": "on_off",
       "range": null,
       "type": "BOOL",
-      "used_in_categories": [
-        "hvac_ac",
-        "hvac_air_purifier",
-        "hvac_fan",
-        "hvac_heater",
-        "hvac_radiator",
-        "hvac_underfloor_heating",
-        "kettle",
-        "led_strip",
-        "light",
-        "relay",
-        "socket"
-      ]
+      "used_in_categories": []
     },
     "online": {
       "name": "online",
@@ -1190,10 +1566,7 @@
       "name": "open_left_set",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": [
-        "curtain",
-        "gate"
-      ]
+      "used_in_categories": []
     },
     "open_left_state": {
       "name": "open_left_state",
@@ -1247,10 +1620,7 @@
       "name": "open_right_state",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": [
-        "curtain",
-        "gate"
-      ]
+      "used_in_categories": []
     },
     "open_set": {
       "name": "open_set",
@@ -1426,7 +1796,9 @@
       "name": "volume",
       "range": null,
       "type": "ENUM",
-      "used_in_categories": []
+      "used_in_categories": [
+        "tv"
+      ]
     },
     "volume_int": {
       "name": "volume_int",
@@ -1440,9 +1812,11 @@
       "name": "water_leak_state",
       "range": null,
       "type": "BOOL",
-      "used_in_categories": []
+      "used_in_categories": [
+        "sensor_water_leak"
+      ]
     }
   },
-  "generated_at": "2026-04-12T21:05:04.890060+00:00",
+  "generated_at": "2026-04-12T21:42:23.056807+00:00",
   "source": "https://developers.sber.ru/docs/ru/smarthome/c2c"
 }

--- a/tests/hacs/__snapshots__/sber_schemas.json
+++ b/tests/hacs/__snapshots__/sber_schemas.json
@@ -1,5 +1,21 @@
 {
   "curtain": {
+    "all_features": [
+      "battery_low_power",
+      "battery_percentage",
+      "online",
+      "open_left_percentage",
+      "open_left_set",
+      "open_left_state",
+      "open_percentage",
+      "open_rate",
+      "open_right_percentage",
+      "open_right_set",
+      "open_right_state",
+      "open_set",
+      "open_state",
+      "signal_strength"
+    ],
     "allowed_values": {
       "open_rate": {
         "enum_values": {
@@ -26,9 +42,29 @@
       "open_set",
       "open_state",
       "signal_strength"
+    ],
+    "obligatory": [
+      "online",
+      "open_percentage",
+      "open_set",
+      "open_state"
     ]
   },
   "gate": {
+    "all_features": [
+      "online",
+      "open_left_percentage",
+      "open_left_set",
+      "open_left_state",
+      "open_percentage",
+      "open_rate",
+      "open_right_percentage",
+      "open_right_set",
+      "open_right_state",
+      "open_set",
+      "open_state",
+      "signal_strength"
+    ],
     "allowed_values": {
       "open_rate": {
         "enum_values": {
@@ -55,17 +91,42 @@
       "open_set",
       "open_state",
       "signal_strength"
+    ],
+    "obligatory": [
+      "online",
+      "open_percentage",
+      "open_set",
+      "open_state"
     ]
   },
   "hub": {
+    "all_features": [
+      "online"
+    ],
     "allowed_values": {},
     "category": "hub",
     "dependencies": {},
     "features": [
       "online"
+    ],
+    "obligatory": [
+      "online"
     ]
   },
   "hvac_ac": {
+    "all_features": [
+      "humidity",
+      "hvac_air_flow_direction",
+      "hvac_air_flow_power",
+      "hvac_humidity_set",
+      "hvac_ionization",
+      "hvac_night_mode",
+      "hvac_temp_set",
+      "hvac_work_mode",
+      "on_off",
+      "online",
+      "temperature"
+    ],
     "allowed_values": {
       "hvac_air_flow_power": {
         "enum_values": {
@@ -91,9 +152,25 @@
       "hvac_work_mode",
       "on_off",
       "online"
+    ],
+    "obligatory": [
+      "hvac_temp_set",
+      "on_off",
+      "online"
     ]
   },
   "hvac_air_purifier": {
+    "all_features": [
+      "hvac_air_flow_power",
+      "hvac_aromatization",
+      "hvac_decontaminate",
+      "hvac_ionization",
+      "hvac_night_mode",
+      "hvac_replace_filter",
+      "hvac_replace_ionizator",
+      "on_off",
+      "online"
+    ],
     "allowed_values": {
       "hvac_air_flow_power": {
         "enum_values": {
@@ -119,9 +196,21 @@
       "hvac_replace_ionizator",
       "on_off",
       "online"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "hvac_boiler": {
+    "all_features": [
+      "hvac_heating_rate",
+      "hvac_temp_set",
+      "hvac_thermostat_mode",
+      "on_off",
+      "online",
+      "temperature"
+    ],
     "allowed_values": {
       "hvac_temp_set": {
         "integer_values": {
@@ -140,9 +229,19 @@
       "on_off",
       "online",
       "temperature"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "hvac_fan": {
+    "all_features": [
+      "hvac_air_flow_power",
+      "hvac_direction_set",
+      "on_off",
+      "online"
+    ],
     "allowed_values": {
       "hvac_air_flow_power": {
         "enum_values": {
@@ -163,9 +262,21 @@
       "hvac_air_flow_power",
       "on_off",
       "online"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "hvac_heater": {
+    "all_features": [
+      "hvac_air_flow_power",
+      "hvac_temp_set",
+      "hvac_thermostat_mode",
+      "on_off",
+      "online",
+      "temperature"
+    ],
     "allowed_values": {
       "hvac_air_flow_power": {
         "enum_values": {
@@ -189,9 +300,27 @@
       "on_off",
       "online",
       "temperature"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "hvac_humidifier": {
+    "all_features": [
+      "humidity",
+      "hvac_air_flow_power",
+      "hvac_humidity_set",
+      "hvac_ionization",
+      "hvac_night_mode",
+      "hvac_replace_filter",
+      "hvac_replace_ionizator",
+      "hvac_water_level",
+      "hvac_water_low_level",
+      "hvac_water_percentage",
+      "on_off",
+      "online"
+    ],
     "allowed_values": {
       "hvac_air_flow_power": {
         "enum_values": {
@@ -220,9 +349,19 @@
       "hvac_water_percentage",
       "on_off",
       "online"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "hvac_radiator": {
+    "all_features": [
+      "hvac_temp_set",
+      "on_off",
+      "online",
+      "temperature"
+    ],
     "allowed_values": {
       "hvac_temp_set": {
         "integer_values": {
@@ -240,9 +379,21 @@
       "on_off",
       "online",
       "temperature"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "hvac_underfloor_heating": {
+    "all_features": [
+      "hvac_heating_rate",
+      "hvac_temp_set",
+      "hvac_thermostat_mode",
+      "on_off",
+      "online",
+      "temperature"
+    ],
     "allowed_values": {
       "hvac_temp_set": {
         "integer_values": {
@@ -261,9 +412,19 @@
       "on_off",
       "online",
       "temperature"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "intercom": {
+    "all_features": [
+      "incoming_call",
+      "online",
+      "reject_call",
+      "unlock"
+    ],
     "allowed_values": {},
     "category": "intercom",
     "dependencies": {},
@@ -272,9 +433,21 @@
       "online",
       "reject_call",
       "unlock"
+    ],
+    "obligatory": [
+      "online"
     ]
   },
   "kettle": {
+    "all_features": [
+      "child_lock",
+      "kitchen_water_level",
+      "kitchen_water_low_level",
+      "kitchen_water_temperature",
+      "kitchen_water_temperature_set",
+      "on_off",
+      "online"
+    ],
     "allowed_values": {
       "kitchen_water_temperature_set": {
         "integer_values": {
@@ -295,9 +468,21 @@
       "kitchen_water_temperature_set",
       "on_off",
       "online"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "led_strip": {
+    "all_features": [
+      "light_brightness",
+      "light_colour",
+      "light_colour_temp",
+      "light_mode",
+      "on_off",
+      "online"
+    ],
     "allowed_values": {
       "light_brightness": {
         "integer_values": {
@@ -318,9 +503,21 @@
       "on_off",
       "online",
       "sleep_timer"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "light": {
+    "all_features": [
+      "light_brightness",
+      "light_colour",
+      "light_colour_temp",
+      "light_mode",
+      "on_off",
+      "online"
+    ],
     "allowed_values": {
       "light_brightness": {
         "integer_values": {
@@ -340,9 +537,20 @@
       "light_mode",
       "on_off",
       "online"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "relay": {
+    "all_features": [
+      "current",
+      "on_off",
+      "online",
+      "power",
+      "voltage"
+    ],
     "allowed_values": {
       "power": {
         "integer_values": {
@@ -361,9 +569,36 @@
       "online",
       "power",
       "voltage"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "scenario_button": {
+    "all_features": [
+      "battery_low_power",
+      "battery_percentage",
+      "button_10_event",
+      "button_1_event",
+      "button_2_event",
+      "button_3_event",
+      "button_4_event",
+      "button_5_event",
+      "button_6_event",
+      "button_7_event",
+      "button_8_event",
+      "button_9_event",
+      "button_bottom_left_event",
+      "button_bottom_right_event",
+      "button_event",
+      "button_left_event",
+      "button_right_event",
+      "button_top_left_event",
+      "button_top_right_event",
+      "online",
+      "signal_strength"
+    ],
     "allowed_values": {
       "button_1_event": {
         "enum_values": {
@@ -383,9 +618,21 @@
       "button_2_event",
       "online",
       "signal_strength"
+    ],
+    "obligatory": [
+      "online"
     ]
   },
   "sensor_door": {
+    "all_features": [
+      "battery_low_power",
+      "battery_percentage",
+      "doorcontact_state",
+      "online",
+      "sensor_sensitive",
+      "signal_strength",
+      "tamper_alarm"
+    ],
     "allowed_values": {
       "sensor_sensitive": {
         "enum_values": {
@@ -407,9 +654,22 @@
       "sensor_sensitive",
       "signal_strength",
       "tamper_alarm"
+    ],
+    "obligatory": [
+      "doorcontact_state",
+      "online"
     ]
   },
   "sensor_gas": {
+    "all_features": [
+      "alarm_mute",
+      "battery_low_power",
+      "battery_percentage",
+      "gas_leak_state",
+      "online",
+      "sensor_sensitive",
+      "signal_strength"
+    ],
     "allowed_values": {
       "signal_strength": {
         "enum_values": {
@@ -431,9 +691,21 @@
       "online",
       "sensor_sensitive",
       "signal_strength"
+    ],
+    "obligatory": [
+      "gas_leak_state",
+      "online"
     ]
   },
   "sensor_pir": {
+    "all_features": [
+      "battery_low_power",
+      "battery_percentage",
+      "online",
+      "pir",
+      "sensor_sensitive",
+      "signal_strength"
+    ],
     "allowed_values": {
       "sensor_sensitive": {
         "enum_values": {
@@ -454,9 +726,21 @@
       "pir",
       "sensor_sensitive",
       "signal_strength"
+    ],
+    "obligatory": [
+      "online",
+      "pir"
     ]
   },
   "sensor_smoke": {
+    "all_features": [
+      "alarm_mute",
+      "battery_low_power",
+      "battery_percentage",
+      "online",
+      "signal_strength",
+      "smoke_state"
+    ],
     "allowed_values": {
       "signal_strength": {
         "enum_values": {
@@ -477,9 +761,24 @@
       "online",
       "signal_strength",
       "smoke_state"
+    ],
+    "obligatory": [
+      "online",
+      "smoke_state"
     ]
   },
   "sensor_temp": {
+    "all_features": [
+      "air_pressure",
+      "battery_low_power",
+      "battery_percentage",
+      "humidity",
+      "online",
+      "sensor_sensitive",
+      "signal_strength",
+      "temp_unit_view",
+      "temperature"
+    ],
     "allowed_values": {
       "sensor_sensitive": {
         "enum_values": {
@@ -503,9 +802,21 @@
       "signal_strength",
       "temp_unit_view",
       "temperature"
+    ],
+    "obligatory": [
+      "humidity",
+      "online",
+      "temperature"
     ]
   },
   "sensor_water_leak": {
+    "all_features": [
+      "battery_low_power",
+      "battery_percentage",
+      "online",
+      "signal_strength",
+      "water_leak_state"
+    ],
     "allowed_values": {
       "signal_strength": {
         "enum_values": {
@@ -525,9 +836,21 @@
       "online",
       "signal_strength",
       "water_leak_state"
+    ],
+    "obligatory": [
+      "online",
+      "water_leak_state"
     ]
   },
   "socket": {
+    "all_features": [
+      "child_lock",
+      "current",
+      "on_off",
+      "online",
+      "power",
+      "voltage"
+    ],
     "allowed_values": {
       "power": {
         "integer_values": {
@@ -547,9 +870,26 @@
       "online",
       "power",
       "voltage"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "tv": {
+    "all_features": [
+      "channel",
+      "channel_int",
+      "custom_key",
+      "direction",
+      "mute",
+      "number",
+      "on_off",
+      "online",
+      "source",
+      "volume",
+      "volume_int"
+    ],
     "allowed_values": {
       "source": {
         "enum_values": {
@@ -581,9 +921,22 @@
       "source",
       "volume",
       "volume_int"
+    ],
+    "obligatory": [
+      "on_off",
+      "online"
     ]
   },
   "vacuum_cleaner": {
+    "all_features": [
+      "battery_percentage",
+      "child_lock",
+      "online",
+      "vacuum_cleaner_cleaning_type",
+      "vacuum_cleaner_command",
+      "vacuum_cleaner_program",
+      "vacuum_cleaner_status"
+    ],
     "allowed_values": {
       "vacuum_cleaner_program": {
         "enum_values": {
@@ -606,9 +959,21 @@
       "vacuum_cleaner_command",
       "vacuum_cleaner_program",
       "vacuum_cleaner_status"
+    ],
+    "obligatory": [
+      "online"
     ]
   },
   "valve": {
+    "all_features": [
+      "battery_low_power",
+      "battery_percentage",
+      "online",
+      "open_percentage",
+      "open_set",
+      "open_state",
+      "signal_strength"
+    ],
     "allowed_values": {
       "signal_strength": {
         "enum_values": {
@@ -629,9 +994,26 @@
       "open_set",
       "open_state",
       "signal_strength"
+    ],
+    "obligatory": [
+      "online",
+      "open_percentage",
+      "open_set",
+      "open_state"
     ]
   },
   "window_blind": {
+    "all_features": [
+      "battery_low_power",
+      "battery_percentage",
+      "light_transmission_percentage",
+      "online",
+      "open_percentage",
+      "open_rate",
+      "open_set",
+      "open_state",
+      "signal_strength"
+    ],
     "allowed_values": {
       "open_rate": {
         "enum_values": {
@@ -655,6 +1037,12 @@
       "open_set",
       "open_state",
       "signal_strength"
+    ],
+    "obligatory": [
+      "online",
+      "open_percentage",
+      "open_set",
+      "open_state"
     ]
   }
 }

--- a/tests/hacs/test_codegen_safety.py
+++ b/tests/hacs/test_codegen_safety.py
@@ -18,6 +18,7 @@ import pytest
 from pydantic import ValidationError
 
 from custom_components.sber_mqtt_bridge._generated import (
+    CATEGORY_OBLIGATORY_FEATURES,
     CATEGORY_REFERENCE_FEATURES,
     FEATURE_TYPES,
     SPEC_GENERATED_AT,
@@ -25,6 +26,7 @@ from custom_components.sber_mqtt_bridge._generated import (
 )
 from custom_components.sber_mqtt_bridge.sber_models import (
     SberState,
+    missing_obligatory_features,
     unknown_features_for_category,
 )
 
@@ -65,20 +67,20 @@ class TestFeatureTypeValidator:
 
     def test_pir_as_bool_rejected(self):
         """The real bug that motivated this validator — pir must be ENUM, not BOOL."""
-        with pytest.raises(ValidationError, match="pir.*ENUM"):
+        with pytest.raises(ValidationError, match=r"pir.*ENUM"):
             SberState.model_validate({"key": "pir", "value": {"type": "BOOL", "bool_value": True}})
 
     def test_doorcontact_state_as_enum_rejected(self):
         """doorcontact_state is BOOL per Sber spec, not ENUM."""
-        with pytest.raises(ValidationError, match="doorcontact_state.*BOOL"):
+        with pytest.raises(ValidationError, match=r"doorcontact_state.*BOOL"):
             SberState.model_validate({"key": "doorcontact_state", "value": {"type": "ENUM", "enum_value": "open"}})
 
     def test_on_off_as_integer_rejected(self):
-        with pytest.raises(ValidationError, match="on_off.*BOOL"):
+        with pytest.raises(ValidationError, match=r"on_off.*BOOL"):
             SberState.model_validate({"key": "on_off", "value": {"type": "INTEGER", "integer_value": "1"}})
 
     def test_light_brightness_as_bool_rejected(self):
-        with pytest.raises(ValidationError, match="light_brightness.*INTEGER"):
+        with pytest.raises(ValidationError, match=r"light_brightness.*INTEGER"):
             SberState.model_validate({"key": "light_brightness", "value": {"type": "BOOL", "bool_value": True}})
 
     def test_unknown_feature_allowed(self):
@@ -119,12 +121,45 @@ class TestUnknownFeaturesHelper:
         assert unknown_features_for_category("does_not_exist", {"online"}) == set()
 
 
+class TestObligatoryFeatures:
+    """CATEGORY_OBLIGATORY_FEATURES + missing_obligatory_features() correctness."""
+
+    def test_obligatory_covers_all_categories(self):
+        assert len(CATEGORY_OBLIGATORY_FEATURES) == 28
+
+    def test_online_is_obligatory_almost_everywhere(self):
+        """Every category except possibly exotic ones must have online obligatory."""
+        missing_online = [c for c, oblig in CATEGORY_OBLIGATORY_FEATURES.items() if "online" not in oblig]
+        # online is universally required per Sber spec — if this ever fails,
+        # Sber docs changed or our scraper regressed.
+        assert not missing_online, f"Categories without 'online' obligatory: {missing_online}"
+
+    def test_light_requires_on_off_and_online(self):
+        """Regression guard — our primary test category."""
+        assert CATEGORY_OBLIGATORY_FEATURES["light"] == frozenset({"online", "on_off"})
+
+    def test_sensor_pir_requires_online_and_pir(self):
+        assert CATEGORY_OBLIGATORY_FEATURES["sensor_pir"] == frozenset({"online", "pir"})
+
+    def test_missing_obligatory_detects_incomplete_emission(self):
+        """Device emitting only 'online' for light should flag 'on_off' as missing."""
+        missing = missing_obligatory_features("light", {"online"})
+        assert missing == {"on_off"}
+
+    def test_missing_obligatory_empty_when_all_present(self):
+        assert missing_obligatory_features("light", {"online", "on_off", "light_brightness"}) == set()
+
+    def test_missing_obligatory_unknown_category_empty(self):
+        """Unknown categories fail-open (empty set, not false positive)."""
+        assert missing_obligatory_features("does_not_exist", set()) == set()
+
+
 class TestCodegenDriftCheck:
     """Codegen --check mode must accurately report drift."""
 
     def test_check_mode_succeeds_on_fresh_commit(self):
         """With files freshly regenerated, --check exits 0."""
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603 — sys.executable is trusted
             [sys.executable, str(CODEGEN_SCRIPT), "--check"],
             capture_output=True,
             text=True,
@@ -157,4 +192,5 @@ class TestRuntimeDoesNotReadSpec:
         # re-import in isolation and confirm the data is the same.
         spec_mod = importlib.util.find_spec("custom_components.sber_mqtt_bridge._generated.feature_types")
         assert spec_mod is not None, "feature_types module not importable"
-        assert spec_mod.origin and Path(spec_mod.origin).exists()
+        assert spec_mod.origin
+        assert Path(spec_mod.origin).exists()

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -132,7 +132,10 @@ def render_category_features(spec: dict) -> str:
     categories = spec["categories"]
     lines = [header, "", "CATEGORY_REFERENCE_FEATURES: dict[str, frozenset[str]] = {"]
     for category in sorted(categories):
-        features = sorted(categories[category].get("features", []))
+        # all_features prefers table-extracted full list (superset of
+        # the reference model example).  Fallback to features if table
+        # scraping failed for a page.
+        features = sorted(categories[category].get("all_features") or categories[category].get("features", []))
         if features:
             formatted = ", ".join(f'"{f}"' for f in features)
             lines.append(f'    "{category}": frozenset({{{formatted}}}),')
@@ -141,12 +144,41 @@ def render_category_features(spec: dict) -> str:
     lines.append("}")
     lines.append(
         dedent(
-            '''"""All features listed in the Sber reference model for each category.
+            '''"""All features declared for each category in Sber docs.
 
-This is the *widest* known-valid feature set per category.  Use for
-compliance checks: features we emit outside this set are unknown to
-Sber cloud and likely cause silent rejection (see the TV allowed_values
-bug that motivated this module)."""
+Source: the "Доступные функции устройства" table on each category
+page plus the reference JSON example.  Use as the *widest* known-valid
+feature set per category — features we emit outside this set are
+unknown to Sber cloud and likely cause silent rejection (see the
+TV ``allowed_values`` bug that motivated this module)."""
+            ''',
+        ).strip()
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_obligatory_features(spec: dict) -> str:
+    """Render obligatory_features.py content."""
+    header = HEADER.format(source=spec["source"], generated_at=spec["generated_at"]).rstrip()
+    categories = spec["categories"]
+    lines = [header, "", "CATEGORY_OBLIGATORY_FEATURES: dict[str, frozenset[str]] = {"]
+    for category in sorted(categories):
+        obligatory = sorted(categories[category].get("obligatory", []))
+        if obligatory:
+            formatted = ", ".join(f'"{f}"' for f in obligatory)
+            lines.append(f'    "{category}": frozenset({{{formatted}}}),')
+        else:
+            lines.append(f'    "{category}": frozenset(),')
+    lines.append("}")
+    lines.append(
+        dedent(
+            '''"""Features marked obligatory (``✔︎``) in Sber docs per category.
+
+Extracted from the "Доступные функции устройства" table on each
+category page.  These are the features every device of this category
+MUST emit to be accepted by Sber cloud — emitting fewer is a likely
+cause of silent rejection."""
             ''',
         ).strip()
     )
@@ -162,8 +194,10 @@ def render_init(spec: dict) -> str:
 
         from .category_features import CATEGORY_REFERENCE_FEATURES
         from .feature_types import FEATURE_TYPES
+        from .obligatory_features import CATEGORY_OBLIGATORY_FEATURES
 
         __all__ = [
+            "CATEGORY_OBLIGATORY_FEATURES",
             "CATEGORY_REFERENCE_FEATURES",
             "FEATURE_TYPES",
             "SPEC_GENERATED_AT",
@@ -201,17 +235,18 @@ def atomic_write(path: Path, content: str) -> None:
 def ruff_format_content(content: str, path: Path) -> str:
     """Run content through ``ruff format`` via stdin, keeping input on failure."""
     try:
-        result = subprocess.run(
-            ["ruff", "format", "-", "--stdin-filename", str(path)],
+        # ruff is a trusted dev tool — argv is static.
+        result = subprocess.run(  # noqa: S603
+            ["ruff", "format", "-", "--stdin-filename", str(path)],  # noqa: S607
             input=content,
             capture_output=True,
             text=True,
             check=True,
         )
-        return result.stdout
     except (subprocess.CalledProcessError, FileNotFoundError):
         # ruff not available or failed — keep input unchanged.
         return content
+    return result.stdout
 
 
 def diff_against_committed(path: Path, expected: str) -> str:
@@ -237,6 +272,7 @@ def diff_against_committed(path: Path, expected: str) -> str:
 TARGETS: tuple[tuple[str, str], ...] = (
     ("feature_types.py", "render_feature_types"),
     ("category_features.py", "render_category_features"),
+    ("obligatory_features.py", "render_obligatory_features"),
     ("__init__.py", "render_init"),
 )
 
@@ -259,6 +295,7 @@ def main(argv: list[str] | None = None) -> int:
     renderers = {
         "render_feature_types": render_feature_types,
         "render_category_features": render_category_features,
+        "render_obligatory_features": render_obligatory_features,
         "render_init": render_init,
     }
 

--- a/tools/fetch_sber_schemas.py
+++ b/tools/fetch_sber_schemas.py
@@ -158,15 +158,64 @@ def _normalize_category_schema(raw: dict) -> dict:
 
 
 def extract_category_schema(page, category: str) -> dict | None:
-    """Render a category page, pick the <pre> whose JSON category matches."""
+    """Render a category page, pick the <pre> whose JSON category matches.
+
+    Also extracts the "Доступные функции устройства" table, which marks
+    each feature as obligatory (``✔︎`` in column 2) or optional.  The
+    obligatory set is the strictest feature contract per Sber's own docs.
+    """
     if not _load_page(page, f"{BASE_URL}/{category}"):
         return None
+
     pre_blocks: list[str] = page.eval_on_selector_all("pre", "els => els.map(e => e.innerText)")
+    schema: dict | None = None
     for block in pre_blocks:
         data = _parse_json_block(block)
         if data and data.get("category") == category:
-            return _normalize_category_schema(data)
-    return None
+            schema = _normalize_category_schema(data)
+            break
+    if schema is None:
+        return None
+
+    # Extract obligatory features from the "Доступные функции" table.
+    table_rows = _extract_features_table(page)
+    if table_rows:
+        schema["all_features"] = sorted({row["feature"] for row in table_rows if row["feature"]})
+        schema["obligatory"] = sorted({row["feature"] for row in table_rows if row["obligatory"]})
+    else:
+        # Fallback: no table found (rare — e.g. hub page).  Treat the
+        # reference features as all-features and leave obligatory empty.
+        schema["all_features"] = schema["features"]
+        schema["obligatory"] = []
+    return schema
+
+
+_TABLE_EXTRACTOR_JS = """
+() => {
+  const headings = Array.from(document.querySelectorAll('h2'));
+  const target = headings.find(h => h.innerText.includes('Доступные функции'));
+  if (!target) return [];
+  let el = target.nextElementSibling;
+  while (el && el.tagName !== 'TABLE') el = el.nextElementSibling;
+  if (!el) return [];
+  const rows = Array.from(el.querySelectorAll('tr'));
+  return rows.slice(1).map(tr => {
+    const cells = Array.from(tr.querySelectorAll('td')).map(td => td.innerText.trim());
+    return {
+      feature: cells[0] || '',
+      obligatory: !!(cells[1] && cells[1].length > 0)
+    };
+  });
+}
+"""
+
+
+def _extract_features_table(page) -> list[dict]:
+    """Return rows from the 'Доступные функции устройства' table (may be empty)."""
+    try:
+        return page.evaluate(_TABLE_EXTRACTOR_JS)
+    except Exception:  # noqa: BLE001 — best-effort extraction
+        return []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a third, strictest layer of Sber protocol compliance by extracting the **obligatory** feature markers (✔︎) from the "Доступные функции устройства" table on each category page of developers.sber.ru.

We now have three feature-classification layers:

1. `CATEGORY_REQUIRED_FEATURES` — our narrow hand-curated set (ship-blocking)
2. `CATEGORY_REFERENCE_FEATURES` — auto-generated superset (widest known-valid set)
3. `CATEGORY_OBLIGATORY_FEATURES` — auto-generated from ✔︎ markers (**NEW**) — features Sber explicitly marks mandatory

Missing obligatory features is a likely cause of silent device rejection by Sber cloud.

## Changes

- `tools/fetch_sber_schemas.py` — adds `_extract_features_table()` + JS extractor that finds the "Доступные функции устройства" table and parses the ✔︎ obligatory column
- `tools/codegen.py` — adds `render_obligatory_features()` target
- `custom_components/sber_mqtt_bridge/_generated/obligatory_features.py` — auto-generated
- `custom_components/sber_mqtt_bridge/sber_models.py` — adds `missing_obligatory_features()` helper
- `tests/hacs/test_codegen_safety.py` — 7 new tests for the obligatory layer

## Interesting findings from the scraper

- `valve` obligatory set = `{online, open_percentage, open_set, open_state}` — our `ValveEntity` only emits `{online, open_set, open_state}`. Follow-up: add `open_percentage`.

## Test plan

- [x] All 1715 tests pass locally
- [x] Ruff clean
- [x] `python tools/codegen.py --check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)