### PR TITLE
fix: quote colons in tester_feedback.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/tester_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/tester_feedback.yml
@@ -95,7 +95,7 @@ body:
     id: logs
     attributes:
       label: Релевантные логи
-      description: Логи HA с `logger: custom_components.sber_mqtt_bridge: debug` (если применимо)
+      description: "Логи HA с `logger: custom_components.sber_mqtt_bridge: debug` (если применимо)"
       render: shell
 
   - type: textarea


### PR DESCRIPTION
Template was not appearing in the GitHub issue chooser because YAML parser failed on a colon inside the `logger: ...` example string. Quoted the description line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)