### PR TITLE
feat: per-HA ha_serial_number marker for loop-detection (v1.31.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-04-15
+
+### Added
+
+- **Per-HA `ha_serial_number` marker** для loop-detection. Когда новая
+  настройка `ha_serial_number_enabled` включена в панели (Settings →
+  Loop detection), каждое опубликованное устройство (включая root hub)
+  получает в `partner_meta.ha_serial_number` идентификатор:
+  - реальный `DeviceEntry.serial_number` из HA, либо
+  - нормализованный MAC из `DeviceEntry.connections`, либо
+  - fallback `ha-<8-char-prefix>` от UUID этого Home Assistant.
+
+  Поле кладётся в стандартное `partner_meta` (см. Sber spec
+  `data-structures.md` и VR-003), новых полей в Sber-payload не
+  добавляется. Совместимо с sister-проектом
+  [`dzerik/ha-sberhome`](https://github.com/dzerik/ha-sberhome) v2.9.0+
+  для определения import-loop'ов; более старые версии просто
+  игнорируют поле, обратная совместимость сохраняется.
+
+- Новая настройка `ha_serial_number_enabled` (default `False`) — toggle
+  в группе **Loop detection** на странице настроек панели.
+
 ## [1.30.1] - 2026-04-15
 
 ### Changed

--- a/custom_components/sber_mqtt_bridge/const.py
+++ b/custom_components/sber_mqtt_bridge/const.py
@@ -56,6 +56,17 @@ CONF_CONFIRM_DELAY = "confirm_delay"
 CONF_ACK_AUDIT_DELAY = "ack_audit_delay"
 """Options key for delay (seconds) before auditing unacknowledged entities after config publish."""
 
+CONF_HA_SERIAL_NUMBER = "ha_serial_number_enabled"
+"""Options key for emitting per-HA serial markers in ``partner_meta.ha_serial_number``.
+
+When enabled, every device payload (including the root hub) carries a
+``ha_serial_number`` entry inside ``partner_meta``.  The value is either
+the real ``DeviceEntry.serial_number`` / MAC address from HA's device
+registry, or a fallback derived from this Home Assistant instance UUID
+(``ha-<8-char-prefix>``).  Sister projects that import these devices
+back into HA can use the marker to detect import loops.
+"""
+
 SETTINGS_DEFAULTS: dict[str, int | float | bool] = {
     CONF_RECONNECT_MIN: 5,
     CONF_RECONNECT_MAX: 300,
@@ -66,6 +77,7 @@ SETTINGS_DEFAULTS: dict[str, int | float | bool] = {
     CONF_HUB_AUTO_PARENT: False,
     CONF_CONFIRM_DELAY: 1.5,
     CONF_ACK_AUDIT_DELAY: 60,
+    CONF_HA_SERIAL_NUMBER: False,
 }
 """Default values for bridge operational settings."""
 

--- a/custom_components/sber_mqtt_bridge/devices/base_entity.py
+++ b/custom_components/sber_mqtt_bridge/devices/base_entity.py
@@ -138,6 +138,10 @@ class DeviceData(TypedDict, total=False):
     model_id: str
     hw_version: str
     sw_version: str
+    serial_number: str
+    """Real device serial number from HA device registry (empty string if unknown)."""
+    mac: str
+    """Normalised MAC address pulled from ``DeviceEntry.connections`` (empty if unknown)."""
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/sber_mqtt_bridge/entity_registry.py
+++ b/custom_components/sber_mqtt_bridge/entity_registry.py
@@ -38,6 +38,21 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
+
+def _extract_mac(connections: set[tuple[str, str]] | None) -> str:
+    """Pick a normalised MAC address from ``DeviceEntry.connections``.
+
+    Returns the first ``CONNECTION_NETWORK_MAC`` entry (already normalised
+    by HA) or empty string when none present.
+    """
+    if not connections:
+        return ""
+    for kind, value in connections:
+        if kind == dr.CONNECTION_NETWORK_MAC and value:
+            return value
+    return ""
+
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -233,6 +248,8 @@ class SberEntityLoader:
             "model_id": device.model_id or "",
             "hw_version": device.hw_version or "1",
             "sw_version": device.sw_version or "1",
+            "serial_number": device.serial_number or "",
+            "mac": _extract_mac(device.connections),
         }
         try:
             sber_entity.link_device(device_data)

--- a/custom_components/sber_mqtt_bridge/manifest.json
+++ b/custom_components/sber_mqtt_bridge/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dzerik/sber-mqtt-bridge/issues",
   "loggers": ["aiomqtt"],
   "requirements": ["aiomqtt>=2.0,<3.0", "pydantic>=2.0,<3.0"],
-  "version": "1.30.1"
+  "version": "1.31.0"
 }

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_ACK_AUDIT_DELAY,
     CONF_CONFIRM_DELAY,
     CONF_DEBOUNCE_DELAY,
+    CONF_HA_SERIAL_NUMBER,
     CONF_HUB_AUTO_PARENT,
     CONF_MAX_MQTT_PAYLOAD,
     CONF_MESSAGE_LOG_SIZE,
@@ -160,6 +161,8 @@ class SberBridge:
         self._root_topic = f"{SBER_TOPIC_PREFIX}/{self._login}"
         self._down_topic = f"{self._root_topic}/down"
 
+        self._ha_instance_id_prefix: str = ""
+        """Cached 8-char prefix of HA instance UUID; populated in ``async_start``."""
         self._entities: dict[str, BaseEntity] = {}
         self._enabled_entity_ids: list[str] = []
         self._redefinitions: dict[str, dict] = {}
@@ -305,6 +308,11 @@ class SberBridge:
         return self._stats.as_dict()
 
     @property
+    def ha_serial_prefix(self) -> str | None:
+        """Return active per-HA serial prefix, or ``None`` when feature is off."""
+        return self._ha_instance_id_prefix if self._ha_serial_enabled else None
+
+    @property
     def unacknowledged_entities(self) -> list[str]:
         """Return entity IDs that were published but not yet acknowledged by Sber."""
         return [eid for eid in self._enabled_entity_ids if eid not in self._stats.acknowledged_entities]
@@ -407,6 +415,9 @@ class SberBridge:
         self._message_log_size: int = int(options.get(CONF_MESSAGE_LOG_SIZE, SETTINGS_DEFAULTS[CONF_MESSAGE_LOG_SIZE]))
         self._confirm_delay: float = float(options.get(CONF_CONFIRM_DELAY, SETTINGS_DEFAULTS[CONF_CONFIRM_DELAY]))
         self._ack_audit_delay: float = float(options.get(CONF_ACK_AUDIT_DELAY, SETTINGS_DEFAULTS[CONF_ACK_AUDIT_DELAY]))
+        self._ha_serial_enabled: bool = bool(
+            options.get(CONF_HA_SERIAL_NUMBER, SETTINGS_DEFAULTS[CONF_HA_SERIAL_NUMBER])
+        )
         # verify_ssl has a special path: config_entry.data fallback for migrated entries
         self._verify_ssl: bool = bool(
             options.get(
@@ -483,6 +494,12 @@ class SberBridge:
         MQTT connection is established in a background task with exponential backoff.
         """
         self._running = True
+        # Cache the HA instance UUID prefix so the publish hot-path stays sync.
+        # Used for the per-HA ``ha_serial_number`` loop-detection marker.
+        from homeassistant.helpers import instance_id
+
+        full_uuid = await instance_id.async_get(self._hass)
+        self._ha_instance_id_prefix: str = full_uuid[:8]
         self._load_exposed_entities()
         self._subscribe_ha_events()
         self._connection_task = asyncio.create_task(self._mqtt_connection_loop())
@@ -958,6 +975,7 @@ class SberBridge:
         ha_location = self._hass.config.location_name
         location = ha_location if ha_location and ha_location != "Home Assistant" else "Мой дом"
         auto_parent = self._entry.options.get(CONF_HUB_AUTO_PARENT, False)
+        ha_serial_prefix = self._ha_instance_id_prefix if self._ha_serial_enabled else None
         payload, _config_valid, invalid_ids = build_devices_list_json(
             self._entities,
             ids_to_publish,
@@ -965,6 +983,7 @@ class SberBridge:
             default_home=location,
             default_room=location,
             auto_parent_id=auto_parent,
+            ha_serial_prefix=ha_serial_prefix,
         )
         if invalid_ids:
             self._stats.validation_failures = invalid_ids

--- a/custom_components/sber_mqtt_bridge/sber_protocol.py
+++ b/custom_components/sber_mqtt_bridge/sber_protocol.py
@@ -15,19 +15,29 @@ from .sber_models import validate_config_payload, validate_device, validate_stat
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = "1.30.1"
+VERSION = "1.31.0"
 """Protocol version string included in the hub device descriptor."""
 
 
-def build_hub_device(version: str = VERSION, home: str = "", room: str = "") -> dict:
+def build_hub_device(
+    version: str = VERSION,
+    home: str = "",
+    room: str = "",
+    ha_serial_prefix: str | None = None,
+) -> dict:
     """Build the root hub device descriptor for Sber.
 
     Args:
         version: Protocol version string.
         home: Home name for the hub device.
         room: Room name for the hub device.
+        ha_serial_prefix: When set, the hub device gets a
+            ``partner_meta.ha_serial_number`` value of ``f"ha-{prefix}"``
+            (typically the first 8 chars of the HA instance UUID).  Used
+            by sister integrations that mirror Sber devices back into HA
+            to detect their own loop.  ``None`` disables the marker.
     """
-    return {
+    descriptor: dict = {
         "id": "root",
         "name": "Home Assistant Bridge",
         "default_name": "HA-SberBridge Hub",
@@ -44,6 +54,42 @@ def build_hub_device(version: str = VERSION, home: str = "", room: str = "") -> 
             "features": ["online"],
         },
     }
+    if ha_serial_prefix:
+        descriptor["partner_meta"] = {"ha_serial_number": f"ha-{ha_serial_prefix}"}
+    return descriptor
+
+
+def resolve_ha_serial_number(entity: BaseEntity, ha_serial_prefix: str) -> str:
+    """Resolve the ``ha_serial_number`` marker for one entity.
+
+    Priority:
+        1. Real ``DeviceEntry.serial_number`` if linked to a device.
+        2. Normalised MAC from ``DeviceEntry.connections``.
+        3. Fallback ``f"ha-{ha_serial_prefix}"`` (per-HA-instance marker).
+
+    Args:
+        entity: Entity whose ``linked_device`` may carry HA registry data.
+        ha_serial_prefix: First N chars of the HA instance UUID (used as
+            fallback when the device has no real serial / MAC).
+
+    Returns:
+        Non-empty string suitable for ``partner_meta.ha_serial_number``.
+    """
+    device = entity.linked_device or {}
+    real_serial = (device.get("serial_number") or "").strip()
+    if real_serial:
+        return real_serial
+    mac = (device.get("mac") or "").strip()
+    if mac:
+        return mac
+    return f"ha-{ha_serial_prefix}"
+
+
+def _inject_ha_serial(device_data: dict, serial: str) -> None:
+    """Merge ``ha_serial_number`` into the ``partner_meta`` of a device dict."""
+    meta = dict(device_data.get("partner_meta") or {})
+    meta["ha_serial_number"] = serial
+    device_data["partner_meta"] = meta
 
 
 def build_devices_list_json(
@@ -53,6 +99,7 @@ def build_devices_list_json(
     default_home: str = "",
     default_room: str = "",
     auto_parent_id: bool = True,
+    ha_serial_prefix: str | None = None,
 ) -> tuple[str, bool, list[str]]:
     """Build Sber device config JSON for MQTT publish.
 
@@ -71,13 +118,19 @@ def build_devices_list_json(
         auto_parent_id: When True, automatically set ``parent_id`` to the hub
             ID (``"root"``) for all child devices that don't have an explicit
             parent_id.  This creates a proper hierarchy in Sber cloud.
+        ha_serial_prefix: Per-HA-instance serial prefix.  When provided,
+            every device (including the hub) receives a
+            ``partner_meta.ha_serial_number`` marker; sister integrations
+            use it for loop-detection.  Pass ``None`` to omit markers.
 
     Returns:
         Tuple ``(json_string, validation_passed, invalid_entity_ids)``.
         ``invalid_entity_ids`` lists entities that failed per-device
         validation and were excluded from the payload.
     """
-    device_list: dict[str, Any] = {"devices": [build_hub_device(home=default_home, room=default_room)]}
+    device_list: dict[str, Any] = {
+        "devices": [build_hub_device(home=default_home, room=default_room, ha_serial_prefix=ha_serial_prefix)]
+    }
     invalid_ids: list[str] = []
 
     for entity_id in enabled_entity_ids:
@@ -112,6 +165,9 @@ def build_devices_list_json(
 
         if auto_parent_id and "parent_id" not in device_data:
             device_data["parent_id"] = "root"
+
+        if ha_serial_prefix:
+            _inject_ha_serial(device_data, resolve_ha_serial_number(entity, ha_serial_prefix))
 
         filtered = {k: v for k, v in device_data.items() if v is not None}
 

--- a/custom_components/sber_mqtt_bridge/websocket_api/raw.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/raw.py
@@ -35,7 +35,10 @@ async def ws_raw_config(
     from ..sber_protocol import build_devices_list_json
 
     payload, _valid, _invalid = build_devices_list_json(
-        bridge.entities, bridge.enabled_entity_ids, bridge.redefinitions
+        bridge.entities,
+        bridge.enabled_entity_ids,
+        bridge.redefinitions,
+        ha_serial_prefix=bridge.ha_serial_prefix,
     )
     connection.send_result(msg["id"], {"payload": payload})
 

--- a/custom_components/sber_mqtt_bridge/www/components/sber-settings.js
+++ b/custom_components/sber_mqtt_bridge/www/components/sber-settings.js
@@ -37,6 +37,13 @@ const SETTING_DEFS = [
       { key: "message_log_size", label: "MQTT message log buffer", min: 10, max: 500, step: 10, type: "number" },
     ],
   },
+  {
+    group: "Loop detection",
+    note: "Adds a per-HA marker to partner_meta.ha_serial_number on every published device. Sister integrations that mirror Sber devices back into HA use it to detect import loops. Disabled by default.",
+    fields: [
+      { key: "ha_serial_number_enabled", label: "Emit ha_serial_number marker", type: "toggle" },
+    ],
+  },
 ];
 
 class SberSettings extends LitElement {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sber-mqtt-bridge"
-version = "1.30.1"
+version = "1.31.0"
 description = "Sber Smart Home MQTT Bridge for Home Assistant"
 requires-python = ">=3.13"
 license = "MIT"

--- a/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
+++ b/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.30.1',
+        'hw_version': '1.31.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.30.1',
+        'sw_version': '1.31.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.30.1',
+        'hw_version': '1.31.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.30.1',
+        'sw_version': '1.31.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/snapshots/test_protocol_snapshots.ambr
+++ b/tests/hacs/snapshots/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.30.1',
+        'hw_version': '1.31.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.30.1',
+        'sw_version': '1.31.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.30.1',
+        'hw_version': '1.31.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.30.1',
+        'sw_version': '1.31.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/test_sber_protocol.py
+++ b/tests/hacs/test_sber_protocol.py
@@ -9,6 +9,7 @@ from custom_components.sber_mqtt_bridge.sber_protocol import (
     build_states_list_json,
     parse_sber_command,
     parse_sber_status_request,
+    resolve_ha_serial_number,
 )
 from custom_components.sber_mqtt_bridge.devices.relay import RelayEntity
 from custom_components.sber_mqtt_bridge.devices.sensor_temp import SensorTempEntity
@@ -178,6 +179,64 @@ class TestParseSberStatusRequest(unittest.TestCase):
         payload = json.dumps({"other": "data"})
         result = parse_sber_status_request(payload)
         self.assertEqual(result, [])
+
+
+class TestPerHaSerialNumber(unittest.TestCase):
+    """Per-HA ``ha_serial_number`` marker emitted in ``partner_meta``."""
+
+    HA_PREFIX_A = "8f2a1b3c"
+    HA_PREFIX_B = "deadbeef"
+
+    def setUp(self) -> None:
+        self.entities = {"switch.lamp": RelayEntity(RELAY_ENTITY_DATA)}
+        self.entities["switch.lamp"].fill_by_ha_state(HA_STATE_ON)
+
+    # ----- resolve_ha_serial_number -----
+
+    def test_real_serial_wins_over_fallback(self) -> None:
+        entity = RelayEntity({**RELAY_ENTITY_DATA, "device_id": "dev1"})
+        entity.link_device({"id": "dev1", "serial_number": "ABC-1234", "mac": "aa:bb:cc:dd:ee:ff"})
+        self.assertEqual(resolve_ha_serial_number(entity, self.HA_PREFIX_A), "ABC-1234")
+
+    def test_mac_used_when_no_serial(self) -> None:
+        entity = RelayEntity({**RELAY_ENTITY_DATA, "device_id": "dev1"})
+        entity.link_device({"id": "dev1", "mac": "aa:bb:cc:dd:ee:ff"})
+        self.assertEqual(resolve_ha_serial_number(entity, self.HA_PREFIX_A), "aa:bb:cc:dd:ee:ff")
+
+    def test_fallback_uses_ha_prefix(self) -> None:
+        entity = RelayEntity(RELAY_ENTITY_DATA)
+        # No linked_device at all → fallback path.
+        self.assertEqual(resolve_ha_serial_number(entity, self.HA_PREFIX_A), f"ha-{self.HA_PREFIX_A}")
+
+    def test_two_ha_instances_get_distinct_fallbacks(self) -> None:
+        entity = RelayEntity(RELAY_ENTITY_DATA)
+        a = resolve_ha_serial_number(entity, self.HA_PREFIX_A)
+        b = resolve_ha_serial_number(entity, self.HA_PREFIX_B)
+        self.assertNotEqual(a, b)
+        self.assertTrue(a.startswith("ha-"))
+        self.assertTrue(b.startswith("ha-"))
+
+    # ----- end-to-end through build_devices_list_json -----
+
+    def test_marker_absent_when_disabled(self) -> None:
+        result = json.loads(build_devices_list_json(self.entities, ["switch.lamp"])[0])
+        for device in result["devices"]:
+            self.assertNotIn("partner_meta", device, msg=f"unexpected partner_meta in {device['id']}")
+
+    def test_marker_added_to_hub_when_enabled(self) -> None:
+        result = json.loads(
+            build_devices_list_json(self.entities, ["switch.lamp"], ha_serial_prefix=self.HA_PREFIX_A)[0]
+        )
+        hub = result["devices"][0]
+        self.assertEqual(hub["id"], "root")
+        self.assertEqual(hub["partner_meta"]["ha_serial_number"], f"ha-{self.HA_PREFIX_A}")
+
+    def test_marker_added_to_entity_when_enabled(self) -> None:
+        result = json.loads(
+            build_devices_list_json(self.entities, ["switch.lamp"], ha_serial_prefix=self.HA_PREFIX_A)[0]
+        )
+        device = result["devices"][1]
+        self.assertEqual(device["partner_meta"]["ha_serial_number"], f"ha-{self.HA_PREFIX_A}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Opt-in loop-detection marker emitted in `partner_meta.ha_serial_number` on every published device. Sister projects that mirror Sber devices back into HA (e.g. [`dzerik/ha-sberhome`](https://github.com/dzerik/ha-sberhome) v2.9.0+) use it to tell:

- **Loop**: device originated from THIS HA → must NOT re-import.
- **Valid mirror**: device originated from ANOTHER HA → safe to import.

## Why partner_meta and not a new field

Sber C2C spec does **not** define a `serial_number` field on `Device`. Adding one would break our `extra="forbid"` guard and risk Sber rejecting the payload. `partner_meta` is the standard, documented channel for arbitrary vendor metadata:

- `docs/sber-c2c-spec/data-structures.md:86` — *«Произвольные метаданные (max 1024 символов JSON)»*
- `docs/sber-c2c-spec/validation-rules.md:34` — VR-003 enforces the 1024-char limit (already implemented).
- Source: https://developers.sber.ru/docs/ru/smarthome/c2c/structures

Inside `partner_meta` we add a single key `ha_serial_number`; the parent Pydantic schema (`SberDevice`) needs no changes — `partner_meta` is already typed as `dict[str, Any] | None`.

## How

| Source | Used as `ha_serial_number` |
|---|---|
| `DeviceEntry.serial_number` | real serial (best — survives both bridges → physical-device dedup) |
| `DeviceEntry.connections` MAC | normalised MAC (good fallback) |
| `ha-<8-char-prefix>` of HA instance UUID | per-HA fallback marker |
| (hub device) | always per-HA fallback (no physical device behind it) |

## UI

New **Loop detection** group on the Settings panel with a toggle *Emit ha_serial_number marker*. Default: **off** — opt-in for safety. Setting key: `ha_serial_number_enabled`.

## Compatibility

- `ha-sberhome` v2.9.0+ reads `partner_meta.ha_serial_number`; older versions ignore it. No breaking change either way.
- Sber cloud doesn't validate the contents of `partner_meta`, only the 1024-char total size — well within budget.
- Toggle is off by default → no payload change for existing deployments until the user opts in.

## Tests

- 5 new scenarios in `test_sber_protocol.py::TestPerHaSerialNumber`:
  - real serial > MAC > fallback priority
  - MAC fallback when no serial
  - UUID-prefix fallback when neither
  - two HA instances → distinct fallback markers
  - marker absent when `ha_serial_prefix=None` (default off)
- Snapshot tests updated for v1.31.0 (both `__snapshots__/` and `snapshots/` dirs).
- `pytest tests/hacs/ -k 'not test_config_flow'` → 1765 passed (5 config_flow failures are pre-existing on main).
- `ruff check custom_components/` + `ruff format --check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)