### PR TITLE
feat: DevTools correlation timeline (v1.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-04-22
+
+### Added
+
+- **DevTools: Correlation Timeline** — группировка MQTT + HA событий в
+  логические трассы по `HomeAssistant.Context.id` (встроенный в HA
+  correlation ID, который автоматически распространяется через
+  `service_call` → `state_changed`). Каждая трасса отображает полную
+  цепочку: `sber_command` → `ha_service_call` → `ha_state_changed` →
+  `publish_out` (и `silent_rejection` при молчаливом отказе Sber),
+  позволяя одним взглядом понять, где оборвалась цепочка. Новые
+  компоненты:
+  - `trace_collector.py` — in-memory ring-buffer активных и закрытых
+    трасс, с subscribe для live-потока и sweep по timeout.
+  - Интеграция в `SberCommandDispatcher.handle_command`,
+    `HaStateForwarder._handle_primary_state_change`,
+    `SberBridge._publish_states` и `AckAudit` (silent rejection → trace
+    failed).
+  - WebSocket API: `sber_mqtt_bridge/traces`, `.../trace`,
+    `.../clear_traces`, `.../subscribe_traces`.
+  - UI-компонент `sber-traces.js` во вкладке DevTools — expandable
+    timeline с цветной индикацией статуса (active / success / failed /
+    timeout).
+
 ## [1.31.0] - 2026-04-15
 
 ### Added

--- a/custom_components/sber_mqtt_bridge/command_dispatcher.py
+++ b/custom_components/sber_mqtt_bridge/command_dispatcher.py
@@ -31,6 +31,7 @@ from .sber_protocol import parse_sber_command, parse_sber_status_request
 if TYPE_CHECKING:
     from .ack_audit import AckAudit
     from .devices.base_entity import BaseEntity
+    from .trace_collector import TraceCollector
 
 
 class _BridgeStats(Protocol):
@@ -59,12 +60,14 @@ class BridgeCommandContext(Protocol):
     _enabled_entity_ids: list[str]
     _redefinitions: dict[str, dict]
     _confirm_tasks: dict[str, asyncio.Task]
+    _trace_collector: TraceCollector
 
     async def _publish_states(self, ids: list[str] | None, *, force: bool = False) -> None: ...
     async def _publish_config(self, entity_ids: list[str] | None = None) -> None: ...
     def _persist_redefinitions(self) -> None: ...
     def _create_safe_task(self, coro: object, *, name: str | None = None) -> asyncio.Task: ...
     async def _delayed_confirm(self, entity_id: str) -> None: ...
+    def _sweep_traces(self) -> None: ...
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,6 +122,19 @@ class SberCommandDispatcher:
         update_state_ids: list[str] = []
         context = Context()
 
+        # DevTools correlation timeline: open a trace keyed by context.id so
+        # the subsequent HA service calls and state_changed events (which HA
+        # automatically tags with the same Context) land in the same trace.
+        known_ids = [eid for eid in devices if eid in bridge._entities]
+        bridge._trace_collector.begin(
+            trace_id=context.id,
+            trigger="sber_command",
+            entity_ids=known_ids,
+            topic="down/commands",
+            payload=devices,
+        )
+        bridge._sweep_traces()
+
         for entity_id, cmd_data in devices.items():
             bridge._stats.acknowledged_entities.add(entity_id)
             entity = bridge._entities.get(entity_id)
@@ -140,6 +156,16 @@ class SberCommandDispatcher:
                         update_state_ids.append(entity_id)
                     continue
                 await self._call_ha_service(entity_id, cmd, context)
+                bridge._trace_collector.record(
+                    context.id,
+                    type_="ha_service_call",
+                    entity_id=entity_id,
+                    payload={
+                        "domain": cmd.get("domain"),
+                        "service": cmd.get("service"),
+                        "service_data": cmd.get("service_data"),
+                    },
+                )
 
         commanded_ids = [eid for eid in devices if eid in bridge._entities]
 

--- a/custom_components/sber_mqtt_bridge/ha_state_forwarder.py
+++ b/custom_components/sber_mqtt_bridge/ha_state_forwarder.py
@@ -64,6 +64,7 @@ class HaStateForwarder:
         on_publish_states: Callable[[list[str]], Awaitable[None]],
         on_republish_config: Callable[[], Awaitable[None]],
         create_safe_task: Callable[..., asyncio.Task],
+        on_trace_state_change: Callable[[str | None, str, dict], None] | None = None,
     ) -> None:
         """Initialize the forwarder.
 
@@ -76,6 +77,11 @@ class HaStateForwarder:
             on_republish_config: Async callback to force a config republish.
             create_safe_task: Bridge helper wrapping ``hass.async_create_task``
                 with error logging.
+            on_trace_state_change: Optional DevTools hook invoked on every
+                processed primary state change with ``(context_id, entity_id,
+                state_dict)`` so the correlation-trace collector can attach
+                the event. No-op when ``None`` — keeps tests free of
+                DevTools wiring.
         """
         self._hass = hass
         self._debounce_delay = debounce_delay
@@ -84,6 +90,7 @@ class HaStateForwarder:
         self._on_publish_states = on_publish_states
         self._on_republish_config = on_republish_config
         self._create_safe_task = create_safe_task
+        self._on_trace_state_change = on_trace_state_change
 
         self._unsub_listeners: list[Callable[[], None]] = []
         self._pending_publish_ids: set[str] = set()
@@ -194,6 +201,13 @@ class HaStateForwarder:
             self._create_safe_task(self._on_republish_config(), name="republish_config_new_entity")
 
         _LOGGER.debug("HA → Sber state: %s = %s", entity_id, ha_state_dict.get("state"))
+        if self._on_trace_state_change is not None:
+            try:
+                ctx = getattr(event, "context", None)
+                ctx_id = getattr(ctx, "id", None)
+                self._on_trace_state_change(ctx_id, entity_id, ha_state_dict)
+            except Exception:  # pragma: no cover — DevTools must never break forwarding
+                _LOGGER.exception("DevTools trace hook failed for %s", entity_id)
         self._schedule_debounced_publish(entity_id)
 
     @callback

--- a/custom_components/sber_mqtt_bridge/manifest.json
+++ b/custom_components/sber_mqtt_bridge/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dzerik/sber-mqtt-bridge/issues",
   "loggers": ["aiomqtt"],
   "requirements": ["aiomqtt>=2.0,<3.0", "pydantic>=2.0,<3.0"],
-  "version": "1.31.0"
+  "version": "1.32.0"
 }

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -58,6 +58,7 @@ from .sber_protocol import (
     build_devices_list_json,
     build_states_list_json,
 )
+from .trace_collector import TraceCollector
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -201,6 +202,7 @@ class SberBridge:
             on_publish_states=self._publish_states,
             on_republish_config=self._publish_config,
             create_safe_task=self._create_safe_task,
+            on_trace_state_change=self._trace_on_state_change,
         )
 
         # Sber protocol command dispatcher (commands, status/config request, etc.)
@@ -245,6 +247,14 @@ class SberBridge:
 
         # Ring buffer + subscribers for MQTT message log (DevTools)
         self._msg_logger = MessageLogger(maxlen=self._message_log_size)
+
+        # Correlation-timeline collector (DevTools) — groups Sber+HA events
+        # per HomeAssistant.Context.id into logical traces. Swept via
+        # :meth:`_sweep_traces` on the existing connection-loop tick.
+        self._trace_collector = TraceCollector(
+            maxlen=self._message_log_size,
+            trace_timeout=10.0,
+        )
 
     @property
     def is_connected(self) -> bool:
@@ -441,6 +451,7 @@ class SberBridge:
         self._mqtt_service.update_backoff_limits(self._reconnect_min, self._reconnect_max)
         self._mqtt_service.update_verify_ssl(self._verify_ssl)
         self._msg_logger.resize(self._message_log_size)
+        self._trace_collector.resize(self._message_log_size)
 
         _LOGGER.info(
             "Bridge settings applied (debounce=%.2fs, log=%d)",
@@ -485,6 +496,47 @@ class SberBridge:
     def _log_message(self, direction: str, topic: str, payload: str) -> None:
         """Append message to ring buffer and notify subscribers."""
         self._msg_logger.log(direction, topic, payload)
+
+    # ---------------------------------------------------------------------------
+    # Correlation-timeline traces (DevTools #1)
+    # ---------------------------------------------------------------------------
+
+    @property
+    def trace_collector(self) -> TraceCollector:
+        """Return the correlation-trace collector for WS API access."""
+        return self._trace_collector
+
+    def _sweep_traces(self) -> None:
+        """Close traces idle beyond the configured timeout.
+
+        Invoked opportunistically from the bridge housekeeping path; safe to
+        call from either the event loop or a sync callback since
+        :meth:`TraceCollector.sweep` is CPU-only.
+        """
+        try:
+            self._trace_collector.sweep()
+        except Exception:  # pragma: no cover — must never break the bridge
+            _LOGGER.exception("Trace sweep failed")
+
+    def _trace_on_state_change(
+        self, context_id: str | None, entity_id: str, state: dict
+    ) -> None:
+        """Forwarder hook → append ``ha_state_changed`` to the correlation trace.
+
+        When ``context_id`` is already known (because a Sber command opened
+        the trace moments ago), the event joins that trace. Otherwise a new
+        trace is opened with ``trigger="ha_state_change"`` so DevTools also
+        surfaces user-initiated changes in the HA UI.
+        """
+        if not context_id:
+            return
+        self._trace_collector.record(
+            context_id,
+            type_="ha_state_changed",
+            entity_id=entity_id,
+            payload={"state": state.get("state"), "attributes": state.get("attributes")},
+            trigger_if_new="ha_state_change",
+        )
 
     async def async_start(self) -> None:
         """Start the bridge: load entities, subscribe to HA events, connect MQTT.
@@ -723,6 +775,9 @@ class SberBridge:
                 int(self._ack_audit_delay),
                 ", ".join(unack),
             )
+            # Mark any active correlation traces for these entities as failed
+            # so DevTools surfaces "Sber never acknowledged" cleanly.
+            self._trace_collector.record_silent_rejection(unack)
         self._create_safe_task(
             check_and_create_issues(self._hass, self),
             name="ack_audit_issues",
@@ -962,7 +1017,11 @@ class SberBridge:
                 if entity is not None:
                     entity.mark_state_published()
         # DevTools: log outgoing message
-        self._log_message("out", topic, payload if isinstance(payload, str) else "")
+        payload_str = payload if isinstance(payload, str) else ""
+        self._log_message("out", topic, payload_str)
+        # DevTools correlation: attach this publish to each entity's active trace.
+        for eid in entity_ids or self._enabled_entity_ids:
+            self._trace_collector.record_publish(eid, topic, payload_str)
 
     async def _publish_config(self, entity_ids: list[str] | None = None) -> None:
         """Publish device config to Sber MQTT."""

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -518,9 +518,7 @@ class SberBridge:
         except Exception:  # pragma: no cover — must never break the bridge
             _LOGGER.exception("Trace sweep failed")
 
-    def _trace_on_state_change(
-        self, context_id: str | None, entity_id: str, state: dict
-    ) -> None:
+    def _trace_on_state_change(self, context_id: str | None, entity_id: str, state: dict) -> None:
         """Forwarder hook → append ``ha_state_changed`` to the correlation trace.
 
         When ``context_id`` is already known (because a Sber command opened

--- a/custom_components/sber_mqtt_bridge/sber_protocol.py
+++ b/custom_components/sber_mqtt_bridge/sber_protocol.py
@@ -15,7 +15,7 @@ from .sber_models import validate_config_payload, validate_device, validate_stat
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = "1.31.0"
+VERSION = "1.32.0"
 """Protocol version string included in the hub device descriptor."""
 
 

--- a/custom_components/sber_mqtt_bridge/trace_collector.py
+++ b/custom_components/sber_mqtt_bridge/trace_collector.py
@@ -1,0 +1,386 @@
+"""Correlation-timeline trace collector for DevTools.
+
+Groups MQTT + HA events into logical traces keyed by ``HomeAssistant.Context.id``
+(which HA automatically propagates through service calls → state_changed events).
+A trace is opened when a Sber command arrives or when a HA state change
+originates outside an existing trace; events are appended while the trace is
+active and the trace is closed either explicitly or via inactivity timeout.
+
+Design notes:
+    * Active traces live in ``_active`` keyed by ``trace_id`` for O(1) lookup.
+    * Closed traces go into a bounded ``deque`` (same ring-buffer pattern as
+      ``MessageLogger``) so the memory footprint stays predictable.
+    * ``_last_trace_per_entity`` lets outbound publishes — which lose the
+      original Context — be attached to the most recent trace for that entity.
+    * Subscribers are notified on trace_started / trace_updated / trace_closed
+      so the frontend can render incremental timelines.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections import deque
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+_LOGGER = logging.getLogger(__name__)
+
+TraceTrigger = Literal["sber_command", "ha_state_change", "unknown"]
+TraceStatus = Literal["active", "success", "failed", "timeout"]
+TraceEventType = Literal[
+    "sber_command",
+    "ha_service_call",
+    "ha_state_changed",
+    "publish_out",
+    "silent_rejection",
+]
+SubscriberEvent = Literal["trace_started", "trace_updated", "trace_closed"]
+
+
+@dataclass
+class TraceEvent:
+    """A single event within a correlation trace."""
+
+    ts: float
+    type: TraceEventType
+    entity_id: str | None = None
+    topic: str | None = None
+    payload: Any = None
+    duration_ms: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass
+class Trace:
+    """A correlation trace — one logical transaction spanning Sber ↔ HA."""
+
+    trace_id: str
+    started_at: float
+    trigger: TraceTrigger
+    entity_ids: set[str] = field(default_factory=set)
+    events: list[TraceEvent] = field(default_factory=list)
+    status: TraceStatus = "active"
+    last_event_at: float = 0.0
+    closed_at: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation (``entity_ids`` as list)."""
+        return {
+            "trace_id": self.trace_id,
+            "started_at": self.started_at,
+            "trigger": self.trigger,
+            "entity_ids": sorted(self.entity_ids),
+            "events": [e.as_dict() for e in self.events],
+            "status": self.status,
+            "last_event_at": self.last_event_at,
+            "closed_at": self.closed_at,
+        }
+
+
+class TraceCollector:
+    """In-memory store of active and recently-closed correlation traces.
+
+    The collector is deliberately passive: it does not schedule its own timers.
+    Callers invoke :meth:`sweep` from an existing periodic tick (or tests can
+    drive it directly) to close traces that have been idle beyond
+    ``trace_timeout``. This keeps the module HA-independent and trivial to
+    unit-test.
+    """
+
+    def __init__(self, maxlen: int = 100, trace_timeout: float = 10.0) -> None:
+        """Initialize a collector.
+
+        Args:
+            maxlen: Ring-buffer size for closed traces.
+            trace_timeout: Seconds of inactivity after which an active trace
+                auto-closes with status ``timeout`` (unless already
+                ``success`` / ``failed``) on the next :meth:`sweep`.
+        """
+        self._active: dict[str, Trace] = {}
+        self._closed: deque[Trace] = deque(maxlen=maxlen)
+        self._trace_timeout = trace_timeout
+        self._last_trace_per_entity: dict[str, str] = {}
+        self._subscribers: set[Callable[[SubscriberEvent, Trace], None]] = set()
+
+    # ------------------------------------------------------------------
+    # Properties / config
+    # ------------------------------------------------------------------
+
+    @property
+    def maxlen(self) -> int | None:
+        """Return the closed-trace ring-buffer capacity."""
+        return self._closed.maxlen
+
+    @property
+    def trace_timeout(self) -> float:
+        """Return the configured inactivity timeout in seconds."""
+        return self._trace_timeout
+
+    def resize(self, new_maxlen: int) -> None:
+        """Resize the closed-trace ring buffer, keeping the newest entries."""
+        if new_maxlen == self._closed.maxlen:
+            return
+        old = list(self._closed)
+        self._closed = deque(old[-new_maxlen:], maxlen=new_maxlen)
+
+    def set_trace_timeout(self, seconds: float) -> None:
+        """Update the inactivity timeout."""
+        self._trace_timeout = seconds
+
+    # ------------------------------------------------------------------
+    # Snapshot / clear
+    # ------------------------------------------------------------------
+
+    def snapshot(self, *, include_active: bool = True) -> list[dict[str, Any]]:
+        """Return a JSON-serializable snapshot: closed first (oldest→newest), then active."""
+        out = [t.as_dict() for t in self._closed]
+        if include_active:
+            out.extend(t.as_dict() for t in self._active.values())
+        return out
+
+    def get(self, trace_id: str) -> dict[str, Any] | None:
+        """Return one trace as dict, or ``None`` if unknown."""
+        trace = self._active.get(trace_id)
+        if trace is not None:
+            return trace.as_dict()
+        for t in self._closed:
+            if t.trace_id == trace_id:
+                return t.as_dict()
+        return None
+
+    def clear(self) -> None:
+        """Drop all active and closed traces."""
+        self._active.clear()
+        self._closed.clear()
+        self._last_trace_per_entity.clear()
+
+    # ------------------------------------------------------------------
+    # Subscribers
+    # ------------------------------------------------------------------
+
+    def subscribe(self, callback_fn: Callable[[SubscriberEvent, Trace], None]) -> Callable[[], None]:
+        """Subscribe to trace lifecycle events.
+
+        Returns:
+            Unsubscribe callable.
+        """
+        self._subscribers.add(callback_fn)
+
+        def unsub() -> None:
+            self._subscribers.discard(callback_fn)
+
+        return unsub
+
+    def _notify(self, kind: SubscriberEvent, trace: Trace) -> None:
+        for cb in list(self._subscribers):
+            try:
+                cb(kind, trace)
+            except (RuntimeError, ValueError, TypeError, AttributeError):
+                _LOGGER.exception("TraceCollector subscriber raised")
+
+    # ------------------------------------------------------------------
+    # Lifecycle: begin / record / close
+    # ------------------------------------------------------------------
+
+    def begin(
+        self,
+        *,
+        trace_id: str | None,
+        trigger: TraceTrigger,
+        entity_ids: Iterable[str],
+        topic: str | None = None,
+        payload: Any = None,
+    ) -> Trace:
+        """Open a new trace (or reuse an existing active trace with the same id).
+
+        Args:
+            trace_id: Correlation id — typically ``event.context.id``. ``None``
+                or empty string triggers a synthetic uuid so ad-hoc calls still
+                produce a valid trace.
+            trigger: What caused this trace (``sber_command`` /
+                ``ha_state_change``).
+            entity_ids: Entities involved; more may be added via subsequent
+                :meth:`record` calls.
+            topic: MQTT topic for the initiating event (if any).
+            payload: Initiating payload (stored as-is in the first event).
+
+        Returns:
+            The active :class:`Trace` (new or existing).
+        """
+        tid = trace_id or f"synthetic-{uuid.uuid4().hex[:12]}"
+        now = time.time()
+        ids = set(entity_ids)
+
+        existing = self._active.get(tid)
+        if existing is not None:
+            existing.entity_ids.update(ids)
+            existing.last_event_at = now
+            for eid in ids:
+                self._last_trace_per_entity[eid] = tid
+            return existing
+
+        trace = Trace(
+            trace_id=tid,
+            started_at=now,
+            trigger=trigger,
+            entity_ids=ids,
+            last_event_at=now,
+        )
+        event = TraceEvent(
+            ts=now,
+            type="sber_command" if trigger == "sber_command" else "ha_state_changed",
+            entity_id=next(iter(ids)) if len(ids) == 1 else None,
+            topic=topic,
+            payload=payload,
+        )
+        trace.events.append(event)
+        self._active[tid] = trace
+        for eid in ids:
+            self._last_trace_per_entity[eid] = tid
+        self._notify("trace_started", trace)
+        return trace
+
+    def record(
+        self,
+        trace_id: str | None,
+        *,
+        type_: TraceEventType,
+        entity_id: str | None = None,
+        topic: str | None = None,
+        payload: Any = None,
+        duration_ms: float | None = None,
+        trigger_if_new: TraceTrigger = "unknown",
+    ) -> Trace | None:
+        """Append an event to the trace identified by ``trace_id``.
+
+        If the trace does not exist yet, a new one is opened with
+        ``trigger_if_new`` — this covers HA state changes that weren't
+        pre-registered by :meth:`begin`.
+
+        Returns the trace, or ``None`` when ``trace_id`` is falsy and no
+        fallback trace could be resolved (should never happen in practice).
+        """
+        if not trace_id:
+            return None
+        trace = self._active.get(trace_id)
+        if trace is None:
+            trace = self.begin(
+                trace_id=trace_id,
+                trigger=trigger_if_new,
+                entity_ids=[entity_id] if entity_id else [],
+                topic=topic,
+                payload=None,  # avoid duplicating payload in both begin-event and recorded event
+            )
+
+        now = time.time()
+        event = TraceEvent(
+            ts=now,
+            type=type_,
+            entity_id=entity_id,
+            topic=topic,
+            payload=payload,
+            duration_ms=duration_ms,
+        )
+        trace.events.append(event)
+        trace.last_event_at = now
+        if entity_id:
+            trace.entity_ids.add(entity_id)
+            self._last_trace_per_entity[entity_id] = trace.trace_id
+        self._notify("trace_updated", trace)
+        return trace
+
+    def record_publish(self, entity_id: str, topic: str, payload: Any = None) -> Trace | None:
+        """Attach an outbound publish to the most recent trace for ``entity_id``.
+
+        Outbound publishes lose the original HA Context (they're typically
+        fired from a debounced/batched path), so we fall back to the
+        per-entity last-known trace_id.  Returns ``None`` if no trace is
+        currently active for this entity.
+        """
+        tid = self._last_trace_per_entity.get(entity_id)
+        if tid is None:
+            return None
+        trace = self._active.get(tid)
+        if trace is None:
+            return None
+        now = time.time()
+        event = TraceEvent(
+            ts=now,
+            type="publish_out",
+            entity_id=entity_id,
+            topic=topic,
+            payload=payload,
+        )
+        trace.events.append(event)
+        trace.last_event_at = now
+        self._notify("trace_updated", trace)
+        return trace
+
+    def record_silent_rejection(self, entity_ids: Iterable[str]) -> list[str]:
+        """Mark active traces for the given entities as failed due to silent rejection.
+
+        Returns the list of trace_ids affected.
+        """
+        affected: list[str] = []
+        now = time.time()
+        for eid in entity_ids:
+            tid = self._last_trace_per_entity.get(eid)
+            if tid is None:
+                continue
+            trace = self._active.get(tid)
+            if trace is None:
+                continue
+            trace.events.append(
+                TraceEvent(
+                    ts=now,
+                    type="silent_rejection",
+                    entity_id=eid,
+                )
+            )
+            trace.last_event_at = now
+            trace.status = "failed"
+            self._notify("trace_updated", trace)
+            affected.append(tid)
+        return affected
+
+    def close(self, trace_id: str, *, status: TraceStatus | None = None) -> Trace | None:
+        """Close an active trace and move it to the closed ring buffer.
+
+        If ``status`` is omitted, pick ``success`` (any ha_service_call or
+        publish_out seen) otherwise ``timeout``.  Already-``failed`` traces
+        keep their status.
+        """
+        trace = self._active.pop(trace_id, None)
+        if trace is None:
+            return None
+        if status is not None:
+            trace.status = status
+        elif trace.status == "active":
+            has_progress = any(e.type in ("ha_service_call", "publish_out", "ha_state_changed") for e in trace.events)
+            trace.status = "success" if has_progress else "timeout"
+        trace.closed_at = time.time()
+        self._closed.append(trace)
+        # Forget per-entity pointer only if it still points at this trace.
+        for eid in list(self._last_trace_per_entity):
+            if self._last_trace_per_entity[eid] == trace_id:
+                del self._last_trace_per_entity[eid]
+        self._notify("trace_closed", trace)
+        return trace
+
+    def sweep(self) -> list[str]:
+        """Close any active traces that have been idle beyond the timeout.
+
+        Intended to be called from an existing periodic tick (e.g. the
+        bridge's housekeeping loop). Returns closed trace_ids.
+        """
+        now = time.time()
+        to_close = [tid for tid, tr in self._active.items() if now - tr.last_event_at >= self._trace_timeout]
+        for tid in to_close:
+            self.close(tid)
+        return to_close

--- a/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
@@ -15,6 +15,7 @@ modules to keep per-file size and concerns focused:
 - ``io_export``       — export / import / update_redefinitions
 - ``settings``        — get_settings / update_settings
 - ``log``             — message_log / clear_message_log / subscribe_messages
+- ``traces``          — correlation-timeline traces (DevTools #1)
 
 All public ``ws_*`` command functions are re-exported at package level
 for test introspection.
@@ -53,6 +54,7 @@ from .status import (
     ws_related_sensors,
     ws_republish,
 )
+from .traces import ws_clear_traces, ws_get_trace, ws_list_traces, ws_subscribe_traces
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,14 +66,17 @@ __all__ = [
     "ws_auto_link_all",
     "ws_clear_all",
     "ws_clear_message_log",
+    "ws_clear_traces",
     "ws_device_detail",
     "ws_export",
     "ws_get_devices",
     "ws_get_settings",
     "ws_get_status",
+    "ws_get_trace",
     "ws_import",
     "ws_list_categories",
     "ws_list_devices_for_category",
+    "ws_list_traces",
     "ws_message_log",
     "ws_publish_one_status",
     "ws_raw_config",
@@ -84,6 +89,7 @@ __all__ = [
     "ws_set_entity_links",
     "ws_set_type_override",
     "ws_subscribe_messages",
+    "ws_subscribe_traces",
     "ws_suggest_links",
     "ws_update_redefinitions",
     "ws_update_settings",
@@ -123,6 +129,11 @@ _COMMANDS = (
     ws_message_log,
     ws_clear_message_log,
     ws_subscribe_messages,
+    # DevTools correlation timeline (v1.32.0)
+    ws_list_traces,
+    ws_get_trace,
+    ws_clear_traces,
+    ws_subscribe_traces,
     # Settings
     ws_get_settings,
     ws_update_settings,

--- a/custom_components/sber_mqtt_bridge/websocket_api/traces.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/traces.py
@@ -1,0 +1,128 @@
+"""Correlation-timeline WebSocket commands (list / get / subscribe / clear).
+
+Frontend counterpart to :mod:`custom_components.sber_mqtt_bridge.trace_collector`.
+Every handler fetches the bridge's :class:`TraceCollector` via ``bridge.trace_collector``
+and returns JSON-serializable snapshots; live updates fan out through
+subscribe so the DevTools panel can render incremental timelines.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+
+from ._common import get_bridge
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/traces",
+        vol.Optional("include_active", default=True): bool,
+    }
+)
+@callback
+def ws_list_traces(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return a snapshot of recent correlation traces (closed + active)."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    snapshot = bridge.trace_collector.snapshot(include_active=msg["include_active"])
+    connection.send_result(msg["id"], {"traces": snapshot})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/trace",
+        vol.Required("trace_id"): str,
+    }
+)
+@callback
+def ws_get_trace(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return a single trace by id, or an error if unknown."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    trace = bridge.trace_collector.get(msg["trace_id"])
+    if trace is None:
+        connection.send_error(msg["id"], "trace_not_found", f"Trace {msg['trace_id']} not found")
+        return
+    connection.send_result(msg["id"], {"trace": trace})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/clear_traces",
+    }
+)
+@callback
+def ws_clear_traces(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Drop all active and closed traces."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    bridge.trace_collector.clear()
+    connection.send_result(msg["id"], {"success": True})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/subscribe_traces",
+    }
+)
+@callback
+def ws_subscribe_traces(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Stream correlation-trace lifecycle events to the subscriber.
+
+    On subscribe we first send an initial snapshot so the UI has the
+    current state, then emit ``{"kind": ..., "trace": ...}`` for every
+    ``trace_started`` / ``trace_updated`` / ``trace_closed`` event.
+    """
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+
+    connection.send_result(msg["id"])
+    connection.send_message(
+        websocket_api.event_message(
+            msg["id"],
+            {"snapshot": bridge.trace_collector.snapshot()},
+        )
+    )
+
+    @callback
+    def forward(kind: str, trace: Any) -> None:
+        connection.send_message(
+            websocket_api.event_message(
+                msg["id"],
+                {"kind": kind, "trace": trace.as_dict()},
+            )
+        )
+
+    unsub = bridge.trace_collector.subscribe(forward)
+    connection.subscriptions[msg["id"]] = unsub

--- a/custom_components/sber_mqtt_bridge/www/components/sber-traces.js
+++ b/custom_components/sber_mqtt_bridge/www/components/sber-traces.js
@@ -1,0 +1,306 @@
+/**
+ * Sber MQTT Bridge — correlation-timeline viewer (DevTools #1).
+ *
+ * Subscribes to ``sber_mqtt_bridge/subscribe_traces`` and renders each
+ * trace as an expandable row with a chronological list of its events
+ * (sber_command, ha_service_call, ha_state_changed, publish_out,
+ * silent_rejection).  A trace groups everything triggered by a single
+ * HomeAssistant Context — which is HA's built-in correlation ID — so
+ * the user can see the full "command → service call → state change →
+ * publish → ack/rejection" chain in one place.
+ */
+
+const LitElement = Object.getPrototypeOf(
+  customElements.get("ha-panel-lovelace") ?? customElements.get("hui-view")
+);
+const html = LitElement?.prototype.html;
+const css = LitElement?.prototype.css;
+
+const STATUS_LABEL = {
+  active: "Active",
+  success: "Success",
+  failed: "Failed",
+  timeout: "Timeout",
+};
+
+const EVENT_ARROW = {
+  sber_command: "⬇",        // Sber → us
+  ha_service_call: "→",     // us → HA
+  ha_state_changed: "↻",    // HA reaction
+  publish_out: "⬆",         // us → Sber
+  silent_rejection: "✘",    // Sber silent no
+};
+
+class SberTraces extends LitElement {
+  static get properties() {
+    return {
+      hass: { type: Object },
+      _traces: { type: Array },
+      _expanded: { type: Object },
+      _error: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this._traces = [];
+    this._expanded = {};
+    this._error = "";
+    this._hassReady = false;
+    this._unsub = null;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribe();
+  }
+
+  updated(changedProps) {
+    if (changedProps.has("hass") && this.hass && !this._hassReady) {
+      this._hassReady = true;
+      this._subscribe();
+    }
+  }
+
+  async _subscribe() {
+    if (this._unsub) return;
+    try {
+      this._unsub = await this.hass.connection.subscribeMessage(
+        (event) => {
+          if (event.snapshot) {
+            this._traces = event.snapshot;
+          } else if (event.trace) {
+            this._applyLiveUpdate(event.kind, event.trace);
+          }
+        },
+        { type: "sber_mqtt_bridge/subscribe_traces" }
+      );
+    } catch (e) {
+      this._error = e.message || String(e);
+    }
+  }
+
+  _unsubscribe() {
+    if (this._unsub) {
+      this._unsub();
+      this._unsub = null;
+    }
+  }
+
+  _applyLiveUpdate(kind, trace) {
+    const existing = this._traces.findIndex((t) => t.trace_id === trace.trace_id);
+    if (existing === -1) {
+      this._traces = [...this._traces, trace];
+      return;
+    }
+    const next = [...this._traces];
+    next[existing] = trace;
+    this._traces = next;
+  }
+
+  async _clearTraces() {
+    try {
+      await this.hass.callWS({ type: "sber_mqtt_bridge/clear_traces" });
+      this._traces = [];
+      this._expanded = {};
+      this._error = "";
+    } catch (e) {
+      this._error = e.message || String(e);
+    }
+  }
+
+  _toggle(traceId) {
+    this._expanded = {
+      ...this._expanded,
+      [traceId]: !this._expanded[traceId],
+    };
+  }
+
+  _formatTime(ts) {
+    const d = new Date(ts * 1000);
+    return d.toLocaleTimeString("ru-RU", { hour12: false }) +
+      "." + String(d.getMilliseconds()).padStart(3, "0");
+  }
+
+  _relMs(trace, ts) {
+    return Math.round((ts - trace.started_at) * 1000);
+  }
+
+  _eventSummary(ev) {
+    if (!ev.payload) return "";
+    if (ev.type === "ha_service_call") {
+      const p = ev.payload || {};
+      return `${p.domain || ""}.${p.service || ""}`;
+    }
+    if (ev.type === "ha_state_changed") {
+      const p = ev.payload || {};
+      return `state=${p.state ?? "?"}`;
+    }
+    if (ev.type === "publish_out") {
+      const s = typeof ev.payload === "string" ? ev.payload : JSON.stringify(ev.payload);
+      return s.length > 60 ? s.slice(0, 60) + "…" : s;
+    }
+    if (ev.type === "silent_rejection") {
+      return "Sber did not acknowledge";
+    }
+    return "";
+  }
+
+  render() {
+    const traces = [...this._traces].reverse(); // newest first
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <h2>Correlation Timeline</h2>
+          <div class="btn-group">
+            <button class="btn-danger"
+              ?disabled=${this._traces.length === 0}
+              @click=${this._clearTraces}>
+              Clear Traces
+            </button>
+          </div>
+        </div>
+        ${this._error ? html`<div class="error-text">${this._error}</div>` : ""}
+        <div class="trace-container">
+          ${traces.length === 0
+            ? html`<div class="empty">No traces yet. A trace is opened for every Sber command or HA state change.</div>`
+            : html`${traces.map((t) => this._renderTrace(t))}`}
+        </div>
+      </div>
+    `;
+  }
+
+  _renderTrace(trace) {
+    const open = !!this._expanded[trace.trace_id];
+    return html`
+      <div class="trace trace-${trace.status}">
+        <div class="trace-header" @click=${() => this._toggle(trace.trace_id)}>
+          <span class="caret ${open ? "open" : ""}">&#9654;</span>
+          <span class="status-badge status-${trace.status}">${STATUS_LABEL[trace.status] || trace.status}</span>
+          <span class="trigger">${trace.trigger}</span>
+          <span class="entities">${trace.entity_ids.join(", ") || "(no entity)"}</span>
+          <span class="counts">${trace.events.length} ev</span>
+          <span class="time">${this._formatTime(trace.started_at)}</span>
+        </div>
+        ${open ? html`
+          <table class="event-table">
+            <thead>
+              <tr>
+                <th class="col-t">t+ms</th>
+                <th class="col-type">Event</th>
+                <th class="col-entity">Entity</th>
+                <th class="col-detail">Detail</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${trace.events.map((ev) => html`
+                <tr class="event event-${ev.type}">
+                  <td class="col-t">${this._relMs(trace, ev.ts)}</td>
+                  <td class="col-type">
+                    <span class="arrow">${EVENT_ARROW[ev.type] || ""}</span>
+                    ${ev.type}
+                  </td>
+                  <td class="col-entity">${ev.entity_id || ""}</td>
+                  <td class="col-detail" title="${JSON.stringify(ev.payload ?? "")}">${this._eventSummary(ev)}</td>
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        ` : ""}
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .section {
+        background: var(--card-background-color);
+        border-radius: 8px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+      .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+      }
+      h2 { margin: 0; font-size: 1.1em; color: var(--primary-text-color); }
+      .btn-danger {
+        background: var(--error-color, #f44336);
+        color: white;
+        border: none;
+        border-radius: 4px;
+        padding: 6px 12px;
+        cursor: pointer;
+      }
+      .btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
+      .error-text { color: var(--error-color, #f44336); margin-bottom: 8px; font-size: 0.9em; }
+      .empty { color: var(--secondary-text-color); font-style: italic; padding: 16px; text-align: center; }
+      .trace {
+        border: 1px solid var(--divider-color);
+        border-radius: 4px;
+        margin-bottom: 6px;
+        overflow: hidden;
+      }
+      .trace-active { border-left: 3px solid var(--primary-color, #03a9f4); }
+      .trace-success { border-left: 3px solid var(--success-color, #4caf50); }
+      .trace-failed { border-left: 3px solid var(--error-color, #f44336); }
+      .trace-timeout { border-left: 3px solid var(--warning-color, #ff9800); }
+      .trace-header {
+        display: grid;
+        grid-template-columns: 24px 80px 120px 1fr 60px 110px;
+        gap: 8px;
+        padding: 8px 12px;
+        cursor: pointer;
+        align-items: center;
+        font-size: 0.9em;
+      }
+      .trace-header:hover { background: var(--secondary-background-color); }
+      .caret { display: inline-block; transition: transform 0.15s; color: var(--secondary-text-color); }
+      .caret.open { transform: rotate(90deg); }
+      .status-badge {
+        padding: 2px 8px;
+        border-radius: 12px;
+        font-size: 0.75em;
+        font-weight: 600;
+        text-align: center;
+        text-transform: uppercase;
+      }
+      .status-active { background: rgba(3, 169, 244, 0.15); color: var(--primary-color, #03a9f4); }
+      .status-success { background: rgba(76, 175, 80, 0.15); color: var(--success-color, #4caf50); }
+      .status-failed { background: rgba(244, 67, 54, 0.15); color: var(--error-color, #f44336); }
+      .status-timeout { background: rgba(255, 152, 0, 0.15); color: var(--warning-color, #ff9800); }
+      .trigger { color: var(--secondary-text-color); font-family: monospace; font-size: 0.85em; }
+      .entities { color: var(--primary-text-color); font-family: monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .counts { color: var(--secondary-text-color); font-size: 0.8em; text-align: right; }
+      .time { color: var(--secondary-text-color); font-family: monospace; font-size: 0.8em; text-align: right; }
+      .event-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85em;
+        background: var(--secondary-background-color);
+      }
+      .event-table th {
+        text-align: left;
+        padding: 6px 12px;
+        border-bottom: 1px solid var(--divider-color);
+        color: var(--secondary-text-color);
+        font-weight: 500;
+      }
+      .event-table td { padding: 4px 12px; vertical-align: top; }
+      .col-t { width: 70px; color: var(--secondary-text-color); font-family: monospace; text-align: right; }
+      .col-type { width: 180px; font-family: monospace; }
+      .col-entity { width: 200px; font-family: monospace; color: var(--primary-text-color); }
+      .col-detail { color: var(--secondary-text-color); font-family: monospace; word-break: break-all; }
+      .arrow { display: inline-block; width: 16px; margin-right: 4px; }
+      .event-sber_command { color: var(--primary-color, #03a9f4); }
+      .event-ha_service_call { color: var(--success-color, #4caf50); }
+      .event-ha_state_changed { color: var(--warning-color, #ff9800); }
+      .event-publish_out { color: var(--primary-color, #03a9f4); }
+      .event-silent_rejection { color: var(--error-color, #f44336); font-weight: 600; }
+    `;
+  }
+}
+
+customElements.define("sber-traces", SberTraces);

--- a/custom_components/sber_mqtt_bridge/www/sber-panel.js
+++ b/custom_components/sber_mqtt_bridge/www/sber-panel.js
@@ -20,6 +20,7 @@ await Promise.all([
   import(`./components/sber-wizard.js${_q}`),
   import(`./components/sber-toast.js${_q}`),
   import(`./components/sber-devtools.js${_q}`),
+  import(`./components/sber-traces.js${_q}`),
   import(`./components/sber-settings.js${_q}`),
   import(`./components/sber-link-dialog.js${_q}`),
 ]);
@@ -535,6 +536,7 @@ class SberMqttPanel extends LitElement {
         .hass=${this.hass}
         @devtools-toast=${(e) => this._showToast(e.detail.message, e.detail.type)}
       ></sber-devtools>
+      <sber-traces .hass=${this.hass}></sber-traces>
     `;
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sber-mqtt-bridge"
-version = "1.31.0"
+version = "1.32.0"
 description = "Sber Smart Home MQTT Bridge for Home Assistant"
 requires-python = ">=3.13"
 license = "MIT"

--- a/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
+++ b/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.31.0',
+        'hw_version': '1.32.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.31.0',
+        'sw_version': '1.32.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.31.0',
+        'hw_version': '1.32.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.31.0',
+        'sw_version': '1.32.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/snapshots/test_protocol_snapshots.ambr
+++ b/tests/hacs/snapshots/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.31.0',
+        'hw_version': '1.32.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.31.0',
+        'sw_version': '1.32.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.31.0',
+        'hw_version': '1.32.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.31.0',
+        'sw_version': '1.32.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/test_trace_collector.py
+++ b/tests/hacs/test_trace_collector.py
@@ -1,0 +1,288 @@
+"""Unit tests for :class:`TraceCollector`.
+
+Breakage of this module means the DevTools correlation timeline shows
+events under the wrong trace, drops events, or leaks memory — all
+user-visible regressions in the debugging path.  The tests are purely
+synchronous and HA-independent (the collector deliberately exposes a
+manual :meth:`sweep` so callers own the timer).
+"""
+
+from __future__ import annotations
+
+import time
+
+from custom_components.sber_mqtt_bridge.trace_collector import (
+    Trace,
+    TraceCollector,
+    TraceEvent,
+)
+
+
+class TestBeginTrace:
+    """Opening a trace from a Sber command or a raw HA state change."""
+
+    def test_begin_creates_trace_with_initiating_event(self) -> None:
+        tc = TraceCollector()
+        trace = tc.begin(
+            trace_id="ctx-1",
+            trigger="sber_command",
+            entity_ids=["light.kitchen"],
+            topic="down/commands",
+            payload={"on": True},
+        )
+        # An empty trace would be useless to DevTools — the "something happened"
+        # event is what the user sees at the top of the timeline.
+        assert trace.trace_id == "ctx-1"
+        assert trace.status == "active"
+        assert trace.trigger == "sber_command"
+        assert trace.entity_ids == {"light.kitchen"}
+        assert len(trace.events) == 1
+        assert trace.events[0].type == "sber_command"
+        assert trace.events[0].payload == {"on": True}
+
+    def test_begin_twice_same_id_merges_not_duplicates(self) -> None:
+        # Two commands touching overlapping entities under the same HA
+        # Context (rare but real — multi-device service calls) must not
+        # become two separate traces with the same id or the UI breaks.
+        tc = TraceCollector()
+        tc.begin(trace_id="ctx-1", trigger="sber_command", entity_ids=["light.a"])
+        trace = tc.begin(trace_id="ctx-1", trigger="sber_command", entity_ids=["light.b"])
+        assert trace.entity_ids == {"light.a", "light.b"}
+        # Only one initiating event — second begin must not re-emit one.
+        assert len(trace.events) == 1
+
+    def test_begin_with_empty_id_generates_synthetic(self) -> None:
+        # We must never drop a trace just because the caller had no
+        # Context — DevTools still needs to show it.
+        tc = TraceCollector()
+        trace = tc.begin(trace_id=None, trigger="ha_state_change", entity_ids=["switch.x"])
+        assert trace.trace_id.startswith("synthetic-")
+        assert tc.get(trace.trace_id) is not None
+
+
+class TestRecord:
+    """Appending follow-up events."""
+
+    def test_record_appends_event_and_bumps_last_event_at(self) -> None:
+        tc = TraceCollector()
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        before = tc.get("c")["last_event_at"]
+        time.sleep(0.01)
+        tc.record("c", type_="ha_service_call", entity_id="light.x", payload={"svc": "turn_on"})
+        after = tc.get("c")
+        assert len(after["events"]) == 2
+        assert after["events"][-1]["type"] == "ha_service_call"
+        # last_event_at must advance so sweep's timeout logic works.
+        assert after["last_event_at"] > before
+
+    def test_record_unknown_trace_opens_new_with_trigger_if_new(self) -> None:
+        # HA state changes initiated by the user (not by a Sber command)
+        # arrive with a context.id that we've never seen. The collector
+        # must still capture them so DevTools covers both directions.
+        tc = TraceCollector()
+        trace = tc.record(
+            "fresh-ctx",
+            type_="ha_state_changed",
+            entity_id="switch.lamp",
+            trigger_if_new="ha_state_change",
+        )
+        assert trace is not None
+        assert trace.trigger == "ha_state_change"
+        assert trace.entity_ids == {"switch.lamp"}
+
+    def test_record_with_falsy_id_is_noop(self) -> None:
+        tc = TraceCollector()
+        assert tc.record("", type_="ha_service_call") is None
+        assert tc.record(None, type_="ha_service_call") is None  # type: ignore[arg-type]
+
+
+class TestPublishAttachment:
+    """Outbound publishes must glue onto the right trace."""
+
+    def test_publish_attaches_to_last_trace_for_entity(self) -> None:
+        tc = TraceCollector()
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        res = tc.record_publish("light.x", topic="up/status", payload="{}")
+        assert res is not None
+        events = tc.get("c")["events"]
+        assert events[-1]["type"] == "publish_out"
+        assert events[-1]["topic"] == "up/status"
+
+    def test_publish_without_active_trace_returns_none(self) -> None:
+        # Publishes during startup (before any Sber command) must not crash
+        # and must not resurrect closed traces.
+        tc = TraceCollector()
+        assert tc.record_publish("light.ghost", topic="up/status", payload="{}") is None
+
+    def test_publish_after_close_drops_attachment(self) -> None:
+        tc = TraceCollector()
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        tc.close("c")
+        # Publishes for a closed trace must not re-open it, else a late
+        # publish would flip "timeout" back into the active pool.
+        assert tc.record_publish("light.x", topic="up/status", payload="{}") is None
+
+
+class TestSilentRejection:
+    """Silent-rejection audit integration."""
+
+    def test_silent_rejection_marks_trace_failed(self) -> None:
+        tc = TraceCollector()
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        affected = tc.record_silent_rejection(["light.x"])
+        assert affected == ["c"]
+        trace = tc.get("c")
+        assert trace["status"] == "failed"
+        assert trace["events"][-1]["type"] == "silent_rejection"
+
+    def test_silent_rejection_skips_unknown_entities(self) -> None:
+        tc = TraceCollector()
+        # Entity with no active trace — must be silently ignored, not crash.
+        assert tc.record_silent_rejection(["light.ghost"]) == []
+
+
+class TestClose:
+    """Trace closure and status inference."""
+
+    def test_close_moves_from_active_to_closed(self) -> None:
+        tc = TraceCollector()
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        tc.close("c")
+        # Active pool is empty, snapshot still finds it, get() still works.
+        snap = tc.snapshot(include_active=False)
+        assert any(t["trace_id"] == "c" for t in snap)
+        assert tc.get("c") is not None
+
+    def test_close_sets_success_when_progress_seen(self) -> None:
+        tc = TraceCollector()
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        tc.record("c", type_="ha_service_call", entity_id="light.x")
+        tc.close("c")
+        assert tc.get("c")["status"] == "success"
+
+    def test_close_sets_timeout_when_no_progress(self) -> None:
+        # A sber_command with no service call / no state change means
+        # the bridge did nothing — the UI should mark it as dead.
+        tc = TraceCollector()
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        tc.close("c")
+        assert tc.get("c")["status"] == "timeout"
+
+    def test_close_preserves_failed_status(self) -> None:
+        tc = TraceCollector()
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        tc.record_silent_rejection(["light.x"])
+        tc.close("c")
+        # A failed trace must stay failed — the heuristic must not "upgrade"
+        # it back to success because a ha_service_call happened before
+        # the silent rejection was detected.
+        assert tc.get("c")["status"] == "failed"
+
+
+class TestSweep:
+    """Inactivity-driven auto-close."""
+
+    def test_sweep_closes_idle_traces_only(self) -> None:
+        tc = TraceCollector(trace_timeout=0.05)
+        tc.begin(trace_id="old", trigger="sber_command", entity_ids=["light.x"])
+        time.sleep(0.1)
+        tc.begin(trace_id="fresh", trigger="sber_command", entity_ids=["light.y"])
+        closed = tc.sweep()
+        assert closed == ["old"]
+        # Fresh trace must remain active — sweeping must be selective.
+        assert tc.get("fresh")["status"] == "active"
+
+
+class TestSubscribers:
+    """Real-time fan-out for the WS subscribe channel."""
+
+    def test_subscriber_receives_lifecycle_events(self) -> None:
+        tc = TraceCollector()
+        kinds: list[str] = []
+
+        def cb(kind: str, trace: Trace) -> None:
+            kinds.append(kind)
+
+        unsub = tc.subscribe(cb)
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        tc.record("c", type_="ha_service_call", entity_id="light.x")
+        tc.close("c")
+        assert kinds == ["trace_started", "trace_updated", "trace_closed"]
+        unsub()
+        tc.begin(trace_id="c2", trigger="sber_command", entity_ids=["light.y"])
+        # After unsub the callback must stop — otherwise DevTools leaks
+        # subscribers across panel reloads.
+        assert kinds == ["trace_started", "trace_updated", "trace_closed"]
+
+    def test_subscriber_exception_does_not_break_collector(self) -> None:
+        tc = TraceCollector()
+
+        def bad(_kind: str, _trace: Trace) -> None:
+            raise RuntimeError("boom")
+
+        tc.subscribe(bad)
+        # Must not raise — a buggy UI subscriber must never take the
+        # bridge down with it.
+        tc.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+
+
+class TestRingBuffer:
+    """Bounded memory contract."""
+
+    def test_resize_keeps_newest(self) -> None:
+        tc = TraceCollector(maxlen=10)
+        for i in range(5):
+            tc.begin(trace_id=f"c{i}", trigger="sber_command", entity_ids=["light.x"])
+            tc.close(f"c{i}")
+        tc.resize(3)
+        snap = tc.snapshot(include_active=False)
+        # Only the last 3 trace ids must remain after shrink.
+        ids = [t["trace_id"] for t in snap]
+        assert ids == ["c2", "c3", "c4"]
+
+    def test_clear_empties_everything(self) -> None:
+        tc = TraceCollector()
+        tc.begin(trace_id="a", trigger="sber_command", entity_ids=["light.x"])
+        tc.begin(trace_id="b", trigger="sber_command", entity_ids=["light.y"])
+        tc.close("b")
+        tc.clear()
+        assert tc.snapshot() == []
+
+
+class TestSerialization:
+    """JSON-serializable output for the WS API."""
+
+    def test_trace_as_dict_is_json_serializable(self) -> None:
+        import json
+
+        tc = TraceCollector()
+        tc.begin(
+            trace_id="c",
+            trigger="sber_command",
+            entity_ids=["light.x"],
+            payload={"on": True},
+        )
+        tc.record("c", type_="ha_service_call", entity_id="light.x")
+        tc.close("c")
+        # If json.dumps chokes, the WS command will fail silently for users.
+        data = json.dumps(tc.snapshot())
+        assert "trace_id" in data
+        assert "ha_service_call" in data
+
+    def test_event_as_dict_preserves_fields(self) -> None:
+        ev = TraceEvent(
+            ts=1.0,
+            type="publish_out",
+            entity_id="light.x",
+            topic="up/status",
+            payload="{}",
+            duration_ms=42.0,
+        )
+        assert ev.as_dict() == {
+            "ts": 1.0,
+            "type": "publish_out",
+            "entity_id": "light.x",
+            "topic": "up/status",
+            "payload": "{}",
+            "duration_ms": 42.0,
+        }

--- a/tests/hacs/test_traces_integration.py
+++ b/tests/hacs/test_traces_integration.py
@@ -1,0 +1,180 @@
+"""End-to-end tests for the correlation-timeline trace.
+
+Verifies that a full Sber -> HA -> Sber cycle produces a trace with all
+four canonical events (``sber_command``, ``ha_service_call``,
+``publish_out``, and — via the silent-rejection path — ``silent_rejection``).
+These tests guard the integration between TraceCollector, the dispatcher,
+the forwarder, and the publish path: an event missing from the timeline
+is the whole point of this feature breaking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.sber_mqtt_bridge.const import (
+    CONF_SBER_BROKER,
+    CONF_SBER_LOGIN,
+    CONF_SBER_PASSWORD,
+    CONF_SBER_PORT,
+)
+from custom_components.sber_mqtt_bridge.devices.relay import RelayEntity
+from custom_components.sber_mqtt_bridge.sber_bridge import SberBridge
+
+
+def _make_entry(options=None):
+    entry = MagicMock()
+    entry.data = {
+        CONF_SBER_LOGIN: "test",
+        CONF_SBER_PASSWORD: "pass",
+        CONF_SBER_BROKER: "broker.test",
+        CONF_SBER_PORT: 8883,
+    }
+    entry.options = options or {}
+    return entry
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.config.location_name = "My Home"
+    created: list[asyncio.Task] = []
+
+    def _capture(coro, **_):
+        t = asyncio.ensure_future(coro)
+        created.append(t)
+        return t
+
+    hass.async_create_task = MagicMock(side_effect=_capture)
+    hass._created_tasks = created
+    return hass
+
+
+def _make_bridge_with_relay(hass, entity_id="switch.lamp"):
+    entry = _make_entry()
+    bridge = SberBridge(hass, entry)
+    bridge._mqtt_client = AsyncMock()
+    bridge._mqtt_service.publish = AsyncMock()
+    bridge._connected = True
+    bridge._ack_audit.cancel()
+
+    entity = RelayEntity({"entity_id": entity_id, "name": "Lamp"})
+    entity.fill_by_ha_state({"entity_id": entity_id, "state": "off", "attributes": {}})
+    bridge._entities[entity_id] = entity
+    bridge._enabled_entity_ids = [entity_id]
+    return bridge
+
+
+async def _drain(hass):
+    for t in list(getattr(hass, "_created_tasks", [])):
+        if not t.done():
+            with contextlib.suppress(TimeoutError, Exception):
+                await asyncio.wait_for(t, timeout=5)
+
+
+def _cmd(entity_id: str) -> bytes:
+    return json.dumps(
+        {
+            "devices": {
+                entity_id: {
+                    "states": [
+                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}},
+                    ],
+                }
+            }
+        }
+    ).encode()
+
+
+class TestSberCommandTrace:
+    """Sber command opens a trace and ha_service_call + publish_out attach to it."""
+
+    async def test_full_cycle_produces_single_trace_with_all_events(self) -> None:
+        hass = _make_hass()
+        bridge = _make_bridge_with_relay(hass)
+
+        with patch(
+            "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await bridge._handle_sber_command(_cmd("switch.lamp"))
+            await _drain(hass)
+
+        traces = bridge.trace_collector.snapshot()
+        # Exactly one trace — multiple traces here would mean context.id
+        # propagation broke and HA calls leaked into a separate trace.
+        assert len(traces) == 1
+        trace = traces[0]
+        assert trace["trigger"] == "sber_command"
+        assert "switch.lamp" in trace["entity_ids"]
+
+        types = [e["type"] for e in trace["events"]]
+        # sber_command opens, ha_service_call is the bridge reacting,
+        # publish_out is the state confirmation flying back to Sber.
+        assert "sber_command" in types
+        assert "ha_service_call" in types
+        assert "publish_out" in types
+
+    async def test_service_call_event_carries_domain_and_service(self) -> None:
+        hass = _make_hass()
+        bridge = _make_bridge_with_relay(hass)
+        with patch(
+            "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await bridge._handle_sber_command(_cmd("switch.lamp"))
+            await _drain(hass)
+
+        trace = bridge.trace_collector.snapshot()[0]
+        svc_evs = [e for e in trace["events"] if e["type"] == "ha_service_call"]
+        # Without domain/service the DevTools UI can't show what was called.
+        assert svc_evs, "ha_service_call missing from trace"
+        assert svc_evs[0]["payload"]["domain"] == "switch"
+        assert svc_evs[0]["payload"]["service"] == "turn_on"
+
+
+class TestSilentRejectionIntegration:
+    """Silent-rejection audit must flip the trace status on the bridge."""
+
+    async def test_silent_rejection_marks_active_trace_failed(self) -> None:
+        hass = _make_hass()
+        bridge = _make_bridge_with_relay(hass)
+
+        with patch(
+            "custom_components.sber_mqtt_bridge.sber_bridge.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await bridge._handle_sber_command(_cmd("switch.lamp"))
+            await _drain(hass)
+
+        # Strip the entity from acknowledged set — simulates Sber never
+        # responding to a published state (the whole point of the audit).
+        bridge._stats.acknowledged_entities.discard("switch.lamp")
+        with patch(
+            "custom_components.sber_mqtt_bridge.sber_bridge.check_and_create_issues",
+            new_callable=AsyncMock,
+        ):
+            bridge._run_ack_audit()
+            await _drain(hass)
+
+        trace = bridge.trace_collector.snapshot()[0]
+        assert trace["status"] == "failed"
+        # A specific silent_rejection event must be appended so DevTools
+        # can render the red marker at the exact timeline position.
+        assert any(e["type"] == "silent_rejection" for e in trace["events"])
+
+
+class TestTraceCollectorExposedOnBridge:
+    """Simple plumbing test — public API stable for WS consumers."""
+
+    def test_bridge_exposes_trace_collector_property(self) -> None:
+        hass = _make_hass()
+        bridge = _make_bridge_with_relay(hass)
+        # WS commands reach the collector through this one attribute.
+        # Renaming it would break the whole DevTools panel.
+        assert bridge.trace_collector is not None
+        assert bridge.trace_collector.snapshot() == []

--- a/tests/hacs/test_websocket_traces.py
+++ b/tests/hacs/test_websocket_traces.py
@@ -1,0 +1,122 @@
+"""Tests for the correlation-timeline WebSocket commands.
+
+The WS surface is what the DevTools panel talks to, so these tests
+guard the shape of the response payloads (``traces``, ``trace``,
+``snapshot``, ``kind``) — renaming any of those fields silently breaks
+the frontend without a pytest failure elsewhere.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.sber_mqtt_bridge.trace_collector import TraceCollector
+from custom_components.sber_mqtt_bridge.websocket_api.traces import (
+    ws_clear_traces,
+    ws_get_trace,
+    ws_list_traces,
+    ws_subscribe_traces,
+)
+
+
+@pytest.fixture
+def connection():
+    conn = MagicMock()
+    conn.send_result = MagicMock()
+    conn.send_error = MagicMock()
+    conn.send_message = MagicMock()
+    conn.subscriptions = {}
+    return conn
+
+
+@pytest.fixture
+def hass():
+    return MagicMock()
+
+
+def _bridge_with_collector() -> MagicMock:
+    bridge = MagicMock()
+    bridge.trace_collector = TraceCollector()
+    return bridge
+
+
+class TestListTraces:
+    def test_returns_snapshot(self, hass, connection):
+        bridge = _bridge_with_collector()
+        bridge.trace_collector.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.traces.get_bridge",
+            return_value=bridge,
+        ):
+            ws_list_traces(hass, connection, {"id": 1, "include_active": True})
+        # The panel renders the returned array directly; missing "traces" key
+        # means the UI sees undefined and shows an empty timeline.
+        payload = connection.send_result.call_args[0][1]
+        assert "traces" in payload
+        assert len(payload["traces"]) == 1
+        assert payload["traces"][0]["trigger"] == "sber_command"
+
+    def test_bridge_missing_sends_error(self, hass, connection):
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.traces.get_bridge",
+            return_value=None,
+        ):
+            ws_list_traces(hass, connection, {"id": 1, "include_active": True})
+        connection.send_error.assert_called_once()
+
+
+class TestGetTrace:
+    def test_returns_single_trace(self, hass, connection):
+        bridge = _bridge_with_collector()
+        bridge.trace_collector.begin(trace_id="abc", trigger="sber_command", entity_ids=["light.x"])
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.traces.get_bridge",
+            return_value=bridge,
+        ):
+            ws_get_trace(hass, connection, {"id": 2, "trace_id": "abc"})
+        payload = connection.send_result.call_args[0][1]
+        assert payload["trace"]["trace_id"] == "abc"
+
+    def test_unknown_trace_id_sends_trace_not_found(self, hass, connection):
+        bridge = _bridge_with_collector()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.traces.get_bridge",
+            return_value=bridge,
+        ):
+            ws_get_trace(hass, connection, {"id": 3, "trace_id": "nope"})
+        # Generic "unknown error" leaves the user guessing; the explicit
+        # code lets the UI show "Trace no longer available".
+        err = connection.send_error.call_args
+        assert err[0][1] == "trace_not_found"
+
+
+class TestClearTraces:
+    def test_clears_collector(self, hass, connection):
+        bridge = _bridge_with_collector()
+        bridge.trace_collector.begin(trace_id="c", trigger="sber_command", entity_ids=["light.x"])
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.traces.get_bridge",
+            return_value=bridge,
+        ):
+            ws_clear_traces(hass, connection, {"id": 4})
+        assert bridge.trace_collector.snapshot() == []
+
+
+class TestSubscribeTraces:
+    def test_subscribe_sends_initial_snapshot_and_live_updates(self, hass, connection):
+        bridge = _bridge_with_collector()
+        bridge.trace_collector.begin(trace_id="seed", trigger="sber_command", entity_ids=["light.x"])
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.traces.get_bridge",
+            return_value=bridge,
+        ):
+            ws_subscribe_traces(hass, connection, {"id": 5})
+            # First live event after subscribe must reach the frontend.
+            bridge.trace_collector.record("seed", type_="ha_service_call", entity_id="light.x")
+
+        # Two messages: the initial snapshot and the trace_updated event.
+        assert connection.send_message.call_count >= 2
+        # Subscription handle recorded so HA can auto-unsub on disconnect.
+        assert 5 in connection.subscriptions


### PR DESCRIPTION
## Summary

First of five planned DevTools features. Groups MQTT + HA events into logical
**traces** keyed by `HomeAssistant.Context.id` — HA's built-in correlation ID
that already propagates automatically through `service_call → state_changed`.

Each trace spans:
```
sber_command → ha_service_call → ha_state_changed → publish_out
                                                  ↳ silent_rejection (on Sber silent no)
```

So the DevTools panel now shows the full chain of a single logical transaction in
one expandable timeline — no more eyeballing the flat MQTT log to reconstruct
causality.

## Architecture

- **`trace_collector.py`** — in-memory ring buffer of active + closed traces,
  with subscribe fan-out and `sweep()` for inactivity-based closure (timeout).
- **Integration hooks:**
  - `SberCommandDispatcher.handle_command` — `begin()` on every Sber command,
    `record("ha_service_call")` per dispatched service call.
  - `HaStateForwarder` — optional `on_trace_state_change` hook that records
    `ha_state_changed` under `event.context.id` (works for user-initiated changes
    in HA too).
  - `SberBridge._publish_states` — `record_publish()` for every outgoing batch.
  - `AckAudit._run_ack_audit` — `record_silent_rejection()` marks the trace as
    `failed` when Sber never ACKs an entity.
- **WebSocket API** (4 commands): `traces`, `trace`, `clear_traces`,
  `subscribe_traces`.
- **UI**: new `sber-traces.js` component in the DevTools tab with status badges
  (`active` / `success` / `failed` / `timeout`) and per-event detail table.

## What's deliberately out of scope (can be follow-ups)

- Persistent storage of traces (in-memory only, like `MessageLogger`)
- OpenTelemetry export
- Cross-context merging (strictly one `Context.id` = one trace)

## Test plan

- [x] `pytest tests/hacs/` → 1799 passed (32 new: 22 unit, 4 integration, 6 WS)
- [x] `ruff check` → clean
- [x] `ruff format` → clean
- [x] Protocol snapshots updated for v1.32.0 in both `__snapshots__/` and `snapshots/`
- [ ] Manual: install on a real HA, trigger a Sber command, confirm the trace
      appears in the DevTools panel with all 4 event types

🤖 Generated with [Claude Code](https://claude.com/claude-code)