### PR TITLE
feat: DevTools state diffs (v1.33.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-04-22
+
+### Added
+
+- **DevTools: State Diffs** — для каждой исходящей Sber-публикации
+  считается delta по каждому устройству относительно предыдущей
+  публикации и сохраняется только то, что реально изменилось
+  (`added` / `removed` / `changed` с `before` и `after`). Sber-пейлоады
+  повторяют всё состояние при каждой публикации — этот вид убирает
+  шум и показывает одной строкой: `brightness: 50 → 75`,
+  `color: — → [255, 0, 0]`, `on_off (removed)`. Пустые delta не
+  записываются. Новые компоненты:
+  - `state_diff.py` — `DiffCollector` с ring-buffer'ом, per-entity
+    baseline и subscribe для live-потока.
+  - Интеграция в `SberBridge._publish_states` через
+    `DiffCollector.record_publish_payload` (парсит уже сериализованный
+    JSON, ничего не ломая в publish-пути).
+  - WebSocket API: `sber_mqtt_bridge/state_diffs`,
+    `.../clear_state_diffs`, `.../subscribe_state_diffs`.
+  - UI-компонент `sber-state-diff.js` во вкладке DevTools — таблица
+    delta-строк с цветной подсветкой `+` / `−` / `~`.
+
 ## [1.32.0] - 2026-04-22
 
 ### Added

--- a/custom_components/sber_mqtt_bridge/manifest.json
+++ b/custom_components/sber_mqtt_bridge/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dzerik/sber-mqtt-bridge/issues",
   "loggers": ["aiomqtt"],
   "requirements": ["aiomqtt>=2.0,<3.0", "pydantic>=2.0,<3.0"],
-  "version": "1.32.0"
+  "version": "1.33.0"
 }

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -58,6 +58,7 @@ from .sber_protocol import (
     build_devices_list_json,
     build_states_list_json,
 )
+from .state_diff import DiffCollector
 from .trace_collector import TraceCollector
 
 _LOGGER = logging.getLogger(__name__)
@@ -256,6 +257,11 @@ class SberBridge:
             trace_timeout=10.0,
         )
 
+        # State-diff collector (DevTools) — records per-entity deltas
+        # for every outbound Sber state publish so the panel can show
+        # "what actually changed" instead of the full repetitive payload.
+        self._diff_collector = DiffCollector(maxlen=self._message_log_size)
+
     @property
     def is_connected(self) -> bool:
         """Return True if connected to Sber MQTT."""
@@ -452,6 +458,7 @@ class SberBridge:
         self._mqtt_service.update_verify_ssl(self._verify_ssl)
         self._msg_logger.resize(self._message_log_size)
         self._trace_collector.resize(self._message_log_size)
+        self._diff_collector.resize(self._message_log_size)
 
         _LOGGER.info(
             "Bridge settings applied (debounce=%.2fs, log=%d)",
@@ -505,6 +512,11 @@ class SberBridge:
     def trace_collector(self) -> TraceCollector:
         """Return the correlation-trace collector for WS API access."""
         return self._trace_collector
+
+    @property
+    def diff_collector(self) -> DiffCollector:
+        """Return the state-diff collector for WS API access."""
+        return self._diff_collector
 
     def _sweep_traces(self) -> None:
         """Close traces idle beyond the configured timeout.
@@ -1020,6 +1032,11 @@ class SberBridge:
         # DevTools correlation: attach this publish to each entity's active trace.
         for eid in entity_ids or self._enabled_entity_ids:
             self._trace_collector.record_publish(eid, topic, payload_str)
+        # DevTools state-diff: record per-entity deltas from the serialized payload.
+        try:
+            self._diff_collector.record_publish_payload(payload_str, topic=topic)
+        except Exception:  # pragma: no cover — must never break publish
+            _LOGGER.exception("DiffCollector.record_publish_payload failed")
 
     async def _publish_config(self, entity_ids: list[str] | None = None) -> None:
         """Publish device config to Sber MQTT."""

--- a/custom_components/sber_mqtt_bridge/sber_protocol.py
+++ b/custom_components/sber_mqtt_bridge/sber_protocol.py
@@ -15,7 +15,7 @@ from .sber_models import validate_config_payload, validate_device, validate_stat
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = "1.32.0"
+VERSION = "1.33.0"
 """Protocol version string included in the hub device descriptor."""
 
 

--- a/custom_components/sber_mqtt_bridge/state_diff.py
+++ b/custom_components/sber_mqtt_bridge/state_diff.py
@@ -1,0 +1,270 @@
+"""State-payload diff collector for DevTools.
+
+For every Sber state publish we compare the ``{key → value}`` mapping
+of each device against the previously published mapping for the same
+device and keep only the delta — *added*, *removed*, and *changed*
+entries.  Sber state payloads are chatty (every publish re-sends every
+feature value for every affected device), so the raw MQTT log buries
+the actual change in noise; this collector turns each publish into a
+compact "what actually changed" record that DevTools can render in one
+line per feature.
+
+Design notes:
+    * Like :class:`MessageLogger` / :class:`TraceCollector`, the store
+      is an in-memory ring buffer with subscribe fan-out — same memory
+      envelope, same panel-facing API shape.
+    * Empty deltas (publish where nothing changed for a device) are
+      dropped, so the log only surfaces publishes that matter.
+    * ``_last_by_entity`` keeps the rolling baseline; it survives
+      collector-level :meth:`clear` but is reset alongside entity data
+      so stale baselines don't produce phantom "removed" entries.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import time
+from collections import deque
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StateDiff:
+    """Delta between two consecutive Sber state payloads for one device."""
+
+    ts: float
+    entity_id: str
+    topic: str
+    added: dict[str, Any] = field(default_factory=dict)
+    removed: dict[str, Any] = field(default_factory=dict)
+    changed: dict[str, dict[str, Any]] = field(default_factory=dict)
+    """changed[key] = {"before": value, "after": value}"""
+    is_initial: bool = False
+    """True when this is the first publish ever seen for the entity —
+    every key appears under ``added`` and consumers may choose to hide it."""
+
+    @property
+    def is_empty(self) -> bool:
+        """True when nothing changed compared to the previous publish."""
+        return not self.added and not self.removed and not self.changed
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+class DiffCollector:
+    """In-memory ring buffer of recent state diffs with live subscribers.
+
+    The collector is pure Python and HA-independent — callers drive it
+    via :meth:`update` and :meth:`reset_entity`; the bridge wires it
+    into the publish path.
+    """
+
+    def __init__(self, maxlen: int = 200, *, include_initial: bool = False) -> None:
+        """Initialize a collector.
+
+        Args:
+            maxlen: Ring-buffer size for stored diffs.
+            include_initial: Whether the very first publish for an
+                entity should produce a diff (with every key under
+                ``added``).  Off by default — the initial publish is
+                rarely interesting and would otherwise spam the UI
+                on startup.
+        """
+        self._diffs: deque[StateDiff] = deque(maxlen=maxlen)
+        self._last_by_entity: dict[str, dict[str, Any]] = {}
+        self._subscribers: set[Callable[[StateDiff], None]] = set()
+        self._include_initial = include_initial
+
+    # ------------------------------------------------------------------
+    # Properties / config
+    # ------------------------------------------------------------------
+
+    @property
+    def maxlen(self) -> int | None:
+        """Return ring-buffer capacity."""
+        return self._diffs.maxlen
+
+    def resize(self, new_maxlen: int) -> None:
+        """Resize the ring buffer, keeping the newest entries."""
+        if new_maxlen == self._diffs.maxlen:
+            return
+        old = list(self._diffs)
+        self._diffs = deque(old[-new_maxlen:], maxlen=new_maxlen)
+
+    # ------------------------------------------------------------------
+    # Snapshot / clear
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Return all stored diffs as JSON-serializable dicts, oldest first."""
+        return [d.as_dict() for d in self._diffs]
+
+    def clear(self) -> None:
+        """Drop all stored diffs and the per-entity baseline."""
+        self._diffs.clear()
+        self._last_by_entity.clear()
+
+    def reset_entity(self, entity_id: str) -> None:
+        """Forget the baseline for one entity (e.g. when it's removed).
+
+        A subsequent :meth:`update` will treat the entity as brand new.
+        """
+        self._last_by_entity.pop(entity_id, None)
+
+    def get_last_state(self, entity_id: str) -> dict[str, Any] | None:
+        """Return the baseline (key→value) dict for an entity, if any.
+
+        Returned dict is a deep copy so callers can't mutate the baseline.
+        """
+        snap = self._last_by_entity.get(entity_id)
+        return copy.deepcopy(snap) if snap is not None else None
+
+    # ------------------------------------------------------------------
+    # Subscribers
+    # ------------------------------------------------------------------
+
+    def subscribe(self, callback_fn: Callable[[StateDiff], None]) -> Callable[[], None]:
+        """Subscribe to non-empty diffs as they are recorded.
+
+        Returns:
+            Unsubscribe callable.
+        """
+        self._subscribers.add(callback_fn)
+
+        def unsub() -> None:
+            self._subscribers.discard(callback_fn)
+
+        return unsub
+
+    def _notify(self, diff: StateDiff) -> None:
+        for cb in list(self._subscribers):
+            try:
+                cb(diff)
+            except (RuntimeError, ValueError, TypeError, AttributeError):
+                _LOGGER.exception("DiffCollector subscriber raised")
+
+    # ------------------------------------------------------------------
+    # Core: update(entity, states)
+    # ------------------------------------------------------------------
+
+    def update(
+        self,
+        entity_id: str,
+        states: Iterable[dict[str, Any]],
+        topic: str = "up/status",
+    ) -> StateDiff | None:
+        """Compute the diff vs the previous publish and store it.
+
+        Args:
+            entity_id: Sber device identifier (HA entity_id).
+            states: Sber ``states`` list — each item is
+                ``{"key": str, "value": {...}}``.  Items without a
+                ``key`` are ignored.
+            topic: Source topic string, carried into the diff record so
+                DevTools can distinguish ``up/status`` vs ``up/config``
+                if we ever extend to config diffing.
+
+        Returns:
+            The :class:`StateDiff` record (also appended to the ring
+            buffer), or ``None`` when the payload is empty or results
+            in no delta (so non-empty-diff is the only way to reach
+            subscribers).
+        """
+        new_map: dict[str, Any] = {}
+        for s in states:
+            key = s.get("key")
+            if key is None:
+                continue
+            new_map[key] = s.get("value")
+
+        prev = self._last_by_entity.get(entity_id)
+        is_initial = prev is None
+        # Record the new baseline even when the result is uninteresting —
+        # otherwise we'd keep comparing against a stale prior for an
+        # entity that was just re-initialised.
+        self._last_by_entity[entity_id] = copy.deepcopy(new_map)
+
+        if is_initial:
+            if not self._include_initial or not new_map:
+                return None
+            diff = StateDiff(
+                ts=time.time(),
+                entity_id=entity_id,
+                topic=topic,
+                added=copy.deepcopy(new_map),
+                is_initial=True,
+            )
+        else:
+            added = {k: v for k, v in new_map.items() if k not in prev}
+            removed = {k: v for k, v in prev.items() if k not in new_map}
+            changed = {
+                k: {"before": prev[k], "after": new_map[k]} for k in new_map if k in prev and prev[k] != new_map[k]
+            }
+            if not added and not removed and not changed:
+                return None
+            diff = StateDiff(
+                ts=time.time(),
+                entity_id=entity_id,
+                topic=topic,
+                added=copy.deepcopy(added),
+                removed=copy.deepcopy(removed),
+                changed=copy.deepcopy(changed),
+            )
+
+        self._diffs.append(diff)
+        self._notify(diff)
+        return diff
+
+    def record_publish_payload(
+        self,
+        payload: str | dict[str, Any],
+        topic: str = "up/status",
+    ) -> list[StateDiff]:
+        """Parse a full Sber state payload and record a diff per device.
+
+        Convenience entry point for the publish path which already has
+        the serialized JSON.  Invalid JSON / unexpected shape returns
+        an empty list without raising — DevTools must never affect
+        publish success.
+
+        Args:
+            payload: JSON string or pre-parsed dict with the Sber
+                ``{"devices": {entity_id: {"states": [...]}}}`` shape.
+            topic: MQTT topic the payload was sent to.
+
+        Returns:
+            The list of non-empty :class:`StateDiff` records produced
+            (one per changed device).
+        """
+        if isinstance(payload, str):
+            try:
+                import json
+
+                data = json.loads(payload)
+            except (ValueError, TypeError):
+                return []
+        else:
+            data = payload
+
+        devices = data.get("devices") if isinstance(data, dict) else None
+        if not isinstance(devices, dict):
+            return []
+
+        results: list[StateDiff] = []
+        for eid, body in devices.items():
+            if not isinstance(body, dict):
+                continue
+            states = body.get("states")
+            if not isinstance(states, list):
+                continue
+            diff = self.update(eid, states, topic=topic)
+            if diff is not None:
+                results.append(diff)
+        return results

--- a/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
@@ -16,6 +16,7 @@ modules to keep per-file size and concerns focused:
 - ``settings``        — get_settings / update_settings
 - ``log``             — message_log / clear_message_log / subscribe_messages
 - ``traces``          — correlation-timeline traces (DevTools #1)
+- ``diffs``           — state-payload diffs (DevTools #2)
 
 All public ``ws_*`` command functions are re-exported at package level
 for test introspection.
@@ -35,6 +36,7 @@ from .devices_grouped import (
     ws_list_devices_for_category,
     ws_suggest_links,
 )
+from .diffs import ws_clear_state_diffs, ws_list_state_diffs, ws_subscribe_state_diffs
 from .entities import (
     ws_add_entities,
     ws_clear_all,
@@ -66,6 +68,7 @@ __all__ = [
     "ws_auto_link_all",
     "ws_clear_all",
     "ws_clear_message_log",
+    "ws_clear_state_diffs",
     "ws_clear_traces",
     "ws_device_detail",
     "ws_export",
@@ -76,6 +79,7 @@ __all__ = [
     "ws_import",
     "ws_list_categories",
     "ws_list_devices_for_category",
+    "ws_list_state_diffs",
     "ws_list_traces",
     "ws_message_log",
     "ws_publish_one_status",
@@ -89,6 +93,7 @@ __all__ = [
     "ws_set_entity_links",
     "ws_set_type_override",
     "ws_subscribe_messages",
+    "ws_subscribe_state_diffs",
     "ws_subscribe_traces",
     "ws_suggest_links",
     "ws_update_redefinitions",
@@ -134,6 +139,10 @@ _COMMANDS = (
     ws_get_trace,
     ws_clear_traces,
     ws_subscribe_traces,
+    # DevTools state diffs (v1.33.0)
+    ws_list_state_diffs,
+    ws_clear_state_diffs,
+    ws_subscribe_state_diffs,
     # Settings
     ws_get_settings,
     ws_update_settings,

--- a/custom_components/sber_mqtt_bridge/websocket_api/diffs.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/diffs.py
@@ -1,0 +1,92 @@
+"""State-diff WebSocket commands (list / clear / subscribe).
+
+Frontend counterpart to
+:mod:`custom_components.sber_mqtt_bridge.state_diff`.  Every handler
+fetches the bridge's :class:`DiffCollector` via ``bridge.diff_collector``
+and returns JSON-serializable snapshots; live updates fan out via
+subscribe so the DevTools panel renders new diffs as they happen.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+
+from ._common import get_bridge
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/state_diffs",
+    }
+)
+@callback
+def ws_list_state_diffs(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return a snapshot of recorded state diffs, oldest first."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    connection.send_result(msg["id"], {"diffs": bridge.diff_collector.snapshot()})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/clear_state_diffs",
+    }
+)
+@callback
+def ws_clear_state_diffs(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Drop all recorded diffs and the per-entity baseline."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    bridge.diff_collector.clear()
+    connection.send_result(msg["id"], {"success": True})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/subscribe_state_diffs",
+    }
+)
+@callback
+def ws_subscribe_state_diffs(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Stream state diffs to the subscriber.
+
+    Sends an initial ``{"snapshot": [...]}`` event, then ``{"diff": {...}}``
+    for each subsequent non-empty diff.
+    """
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+
+    connection.send_result(msg["id"])
+    connection.send_message(websocket_api.event_message(msg["id"], {"snapshot": bridge.diff_collector.snapshot()}))
+
+    @callback
+    def forward(diff: Any) -> None:
+        connection.send_message(websocket_api.event_message(msg["id"], {"diff": diff.as_dict()}))
+
+    unsub = bridge.diff_collector.subscribe(forward)
+    connection.subscriptions[msg["id"]] = unsub

--- a/custom_components/sber_mqtt_bridge/www/components/sber-state-diff.js
+++ b/custom_components/sber_mqtt_bridge/www/components/sber-state-diff.js
@@ -1,0 +1,261 @@
+/**
+ * Sber MQTT Bridge — state-payload diff viewer (DevTools #2).
+ *
+ * Subscribes to ``sber_mqtt_bridge/subscribe_state_diffs`` and renders
+ * each diff as a compact "what actually changed" row.  Sber payloads
+ * re-send every feature every publish, so the raw log buries the
+ * signal in noise — this view surfaces just the delta:
+ *
+ *     light.kitchen
+ *       ~ light_brightness : 50 → 75
+ *       + light_colour     : [255, 0, 0]
+ *       − on_off
+ */
+
+const LitElement = Object.getPrototypeOf(
+  customElements.get("ha-panel-lovelace") ?? customElements.get("hui-view")
+);
+const html = LitElement?.prototype.html;
+const css = LitElement?.prototype.css;
+
+class SberStateDiff extends LitElement {
+  static get properties() {
+    return {
+      hass: { type: Object },
+      _diffs: { type: Array },
+      _error: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this._diffs = [];
+    this._error = "";
+    this._hassReady = false;
+    this._unsub = null;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribe();
+  }
+
+  updated(changedProps) {
+    if (changedProps.has("hass") && this.hass && !this._hassReady) {
+      this._hassReady = true;
+      this._subscribe();
+    }
+  }
+
+  async _subscribe() {
+    if (this._unsub) return;
+    try {
+      this._unsub = await this.hass.connection.subscribeMessage(
+        (event) => {
+          if (event.snapshot) {
+            this._diffs = event.snapshot;
+          } else if (event.diff) {
+            // Ring-buffer behaviour on the backend caps size — on the UI
+            // side we mirror the append and trust the backend to trim.
+            this._diffs = [...this._diffs, event.diff];
+          }
+        },
+        { type: "sber_mqtt_bridge/subscribe_state_diffs" }
+      );
+    } catch (e) {
+      this._error = e.message || String(e);
+    }
+  }
+
+  _unsubscribe() {
+    if (this._unsub) {
+      this._unsub();
+      this._unsub = null;
+    }
+  }
+
+  async _clear() {
+    try {
+      await this.hass.callWS({ type: "sber_mqtt_bridge/clear_state_diffs" });
+      this._diffs = [];
+      this._error = "";
+    } catch (e) {
+      this._error = e.message || String(e);
+    }
+  }
+
+  _formatTime(ts) {
+    const d = new Date(ts * 1000);
+    return d.toLocaleTimeString("ru-RU", { hour12: false }) +
+      "." + String(d.getMilliseconds()).padStart(3, "0");
+  }
+
+  /** Extract a short human-friendly representation of a Sber value dict. */
+  _formatValue(v) {
+    if (v === null || v === undefined) return "—";
+    if (typeof v !== "object") return String(v);
+    // Sber values are {"type": "BOOL", "bool_value": true} etc. — prefer
+    // the typed field when present, fall back to JSON for unusual shapes.
+    const type = v.type;
+    if (type === "BOOL" && "bool_value" in v) return String(v.bool_value);
+    if (type === "INTEGER" && "integer_value" in v) return String(v.integer_value);
+    if (type === "DOUBLE" && "double_value" in v) return String(v.double_value);
+    if (type === "STRING" && "string_value" in v) return JSON.stringify(v.string_value);
+    if (type === "ENUM" && "enum_value" in v) return String(v.enum_value);
+    if (type === "COLOUR" && "colour_value" in v) {
+      const c = v.colour_value;
+      if (c && typeof c === "object" && "h" in c) {
+        return `h=${c.h} s=${c.s} v=${c.v}`;
+      }
+    }
+    return JSON.stringify(v);
+  }
+
+  render() {
+    const rows = [...this._diffs].reverse();
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <h2>State Diffs</h2>
+          <div class="btn-group">
+            <button class="btn-danger"
+              ?disabled=${this._diffs.length === 0}
+              @click=${this._clear}>
+              Clear Diffs
+            </button>
+          </div>
+        </div>
+        <div class="hint">
+          Each row is the delta between two consecutive state publishes for one device — no delta is emitted when the payload is identical.
+        </div>
+        ${this._error ? html`<div class="error-text">${this._error}</div>` : ""}
+        <div class="diff-container">
+          ${rows.length === 0
+            ? html`<div class="empty">No diffs yet. The first real state change will appear here.</div>`
+            : html`${rows.map((d) => this._renderDiff(d))}`}
+        </div>
+      </div>
+    `;
+  }
+
+  _renderDiff(d) {
+    const changedKeys = Object.keys(d.changed || {}).sort();
+    const addedKeys = Object.keys(d.added || {}).sort();
+    const removedKeys = Object.keys(d.removed || {}).sort();
+    return html`
+      <div class="diff ${d.is_initial ? "diff-initial" : ""}">
+        <div class="diff-header">
+          <span class="entity">${d.entity_id}</span>
+          <span class="topic">${d.topic}</span>
+          ${d.is_initial ? html`<span class="initial-badge">initial</span>` : ""}
+          <span class="time">${this._formatTime(d.ts)}</span>
+        </div>
+        <table class="delta-table">
+          <tbody>
+            ${changedKeys.map((k) => html`
+              <tr class="delta delta-changed">
+                <td class="op">~</td>
+                <td class="key">${k}</td>
+                <td class="from">${this._formatValue(d.changed[k].before)}</td>
+                <td class="arrow">→</td>
+                <td class="to">${this._formatValue(d.changed[k].after)}</td>
+              </tr>
+            `)}
+            ${addedKeys.map((k) => html`
+              <tr class="delta delta-added">
+                <td class="op">+</td>
+                <td class="key">${k}</td>
+                <td class="from"></td>
+                <td class="arrow"></td>
+                <td class="to">${this._formatValue(d.added[k])}</td>
+              </tr>
+            `)}
+            ${removedKeys.map((k) => html`
+              <tr class="delta delta-removed">
+                <td class="op">−</td>
+                <td class="key">${k}</td>
+                <td class="from">${this._formatValue(d.removed[k])}</td>
+                <td class="arrow"></td>
+                <td class="to"></td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .section {
+        background: var(--card-background-color);
+        border-radius: 8px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+      .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 6px;
+      }
+      h2 { margin: 0; font-size: 1.1em; color: var(--primary-text-color); }
+      .hint { color: var(--secondary-text-color); font-size: 0.85em; margin-bottom: 12px; }
+      .btn-danger {
+        background: var(--error-color, #f44336);
+        color: white;
+        border: none;
+        border-radius: 4px;
+        padding: 6px 12px;
+        cursor: pointer;
+      }
+      .btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
+      .error-text { color: var(--error-color, #f44336); margin-bottom: 8px; font-size: 0.9em; }
+      .empty { color: var(--secondary-text-color); font-style: italic; padding: 16px; text-align: center; }
+      .diff {
+        border: 1px solid var(--divider-color);
+        border-radius: 4px;
+        padding: 8px 12px;
+        margin-bottom: 6px;
+        background: var(--primary-background-color);
+      }
+      .diff-initial { border-left: 3px solid var(--secondary-text-color); }
+      .diff-header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 6px;
+        font-size: 0.9em;
+      }
+      .entity { font-family: monospace; font-weight: 600; color: var(--primary-text-color); }
+      .topic { font-family: monospace; color: var(--secondary-text-color); font-size: 0.85em; }
+      .initial-badge {
+        background: var(--secondary-background-color);
+        color: var(--secondary-text-color);
+        padding: 1px 8px;
+        border-radius: 10px;
+        font-size: 0.7em;
+        text-transform: uppercase;
+        font-weight: 600;
+      }
+      .time { margin-left: auto; color: var(--secondary-text-color); font-family: monospace; font-size: 0.8em; }
+      .delta-table { width: 100%; border-collapse: collapse; font-family: monospace; font-size: 0.9em; }
+      .delta td { padding: 2px 8px; vertical-align: top; }
+      .op {
+        width: 18px;
+        font-weight: 700;
+        text-align: center;
+      }
+      .key { width: 220px; color: var(--primary-text-color); }
+      .from { color: var(--secondary-text-color); word-break: break-all; }
+      .arrow { width: 20px; text-align: center; color: var(--secondary-text-color); }
+      .to { color: var(--primary-text-color); word-break: break-all; }
+      .delta-changed .op { color: var(--warning-color, #ff9800); }
+      .delta-added .op { color: var(--success-color, #4caf50); }
+      .delta-removed .op { color: var(--error-color, #f44336); }
+      .delta-removed .from { text-decoration: line-through; }
+    `;
+  }
+}
+
+customElements.define("sber-state-diff", SberStateDiff);

--- a/custom_components/sber_mqtt_bridge/www/sber-panel.js
+++ b/custom_components/sber_mqtt_bridge/www/sber-panel.js
@@ -21,6 +21,7 @@ await Promise.all([
   import(`./components/sber-toast.js${_q}`),
   import(`./components/sber-devtools.js${_q}`),
   import(`./components/sber-traces.js${_q}`),
+  import(`./components/sber-state-diff.js${_q}`),
   import(`./components/sber-settings.js${_q}`),
   import(`./components/sber-link-dialog.js${_q}`),
 ]);
@@ -537,6 +538,7 @@ class SberMqttPanel extends LitElement {
         @devtools-toast=${(e) => this._showToast(e.detail.message, e.detail.type)}
       ></sber-devtools>
       <sber-traces .hass=${this.hass}></sber-traces>
+      <sber-state-diff .hass=${this.hass}></sber-state-diff>
     `;
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sber-mqtt-bridge"
-version = "1.32.0"
+version = "1.33.0"
 description = "Sber Smart Home MQTT Bridge for Home Assistant"
 requires-python = ">=3.13"
 license = "MIT"

--- a/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
+++ b/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.32.0',
+        'hw_version': '1.33.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.32.0',
+        'sw_version': '1.33.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.32.0',
+        'hw_version': '1.33.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.32.0',
+        'sw_version': '1.33.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/snapshots/test_protocol_snapshots.ambr
+++ b/tests/hacs/snapshots/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.32.0',
+        'hw_version': '1.33.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.32.0',
+        'sw_version': '1.33.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.32.0',
+        'hw_version': '1.33.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.32.0',
+        'sw_version': '1.33.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/test_state_diff.py
+++ b/tests/hacs/test_state_diff.py
@@ -1,0 +1,298 @@
+"""Unit tests for :class:`DiffCollector`.
+
+A faulty diff collector silently turns "nothing changed" into a
+phantom entry or swallows a real state transition — both break the
+DevTools "what actually changed" view without any other visible
+symptom.  These tests pin the delta algorithm, the ring-buffer
+contract, and the full-payload entry point used by the publish path.
+"""
+
+from __future__ import annotations
+
+import json
+
+from custom_components.sber_mqtt_bridge.state_diff import (
+    DiffCollector,
+    StateDiff,
+)
+
+
+def _v(kind: str, **body) -> dict:
+    """Build a Sber value dict — ``{"type": ..., "<kind>_value": ...}``."""
+    return {"type": kind.upper(), **body}
+
+
+class TestInitialPublish:
+    """First publish per entity must establish a baseline."""
+
+    def test_initial_publish_default_drops_record(self) -> None:
+        # Most users never want to see the startup flood — initial is
+        # silent by default.
+        dc = DiffCollector()
+        res = dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        assert res is None
+        # Baseline is still captured so the next call produces a real diff.
+        assert dc.get_last_state("light.x") == {"on_off": _v("bool", bool_value=True)}
+
+    def test_initial_publish_opt_in_emits_added_record(self) -> None:
+        dc = DiffCollector(include_initial=True)
+        res = dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        assert res is not None
+        assert res.is_initial is True
+        assert "on_off" in res.added
+
+    def test_empty_initial_payload_drops_even_with_opt_in(self) -> None:
+        # A truly empty states list is noise — don't record it even
+        # when the user asked for initial diffs.
+        dc = DiffCollector(include_initial=True)
+        assert dc.update("light.x", []) is None
+
+
+class TestDeltaMath:
+    """The core add/remove/change classification."""
+
+    def _prime(self, dc: DiffCollector, entity="light.x") -> None:
+        dc.update(
+            entity,
+            [
+                {"key": "on_off", "value": _v("bool", bool_value=True)},
+                {"key": "light_brightness", "value": _v("integer", integer_value=50)},
+            ],
+        )
+
+    def test_changed_key_lands_in_changed_with_before_after(self) -> None:
+        dc = DiffCollector()
+        self._prime(dc)
+        res = dc.update(
+            "light.x",
+            [
+                {"key": "on_off", "value": _v("bool", bool_value=True)},
+                {"key": "light_brightness", "value": _v("integer", integer_value=75)},
+            ],
+        )
+        assert res is not None
+        assert res.changed.keys() == {"light_brightness"}
+        # Before/after must both be present — missing "before" turns
+        # the UI into a guessing game about what the previous value was.
+        assert res.changed["light_brightness"]["before"] == _v("integer", integer_value=50)
+        assert res.changed["light_brightness"]["after"] == _v("integer", integer_value=75)
+        assert res.added == {}
+        assert res.removed == {}
+
+    def test_added_key_lands_in_added(self) -> None:
+        dc = DiffCollector()
+        self._prime(dc)
+        res = dc.update(
+            "light.x",
+            [
+                {"key": "on_off", "value": _v("bool", bool_value=True)},
+                {"key": "light_brightness", "value": _v("integer", integer_value=50)},
+                {"key": "light_colour", "value": _v("integer", integer_value=16711680)},
+            ],
+        )
+        assert res is not None
+        assert "light_colour" in res.added
+        assert res.changed == {}
+
+    def test_removed_key_lands_in_removed(self) -> None:
+        dc = DiffCollector()
+        self._prime(dc)
+        res = dc.update(
+            "light.x",
+            [{"key": "on_off", "value": _v("bool", bool_value=True)}],
+        )
+        assert res is not None
+        assert "light_brightness" in res.removed
+        # Keeping the value on removed helps the UI show "what disappeared",
+        # otherwise the removal card would be empty.
+        assert res.removed["light_brightness"] == _v("integer", integer_value=50)
+
+    def test_equal_payload_returns_none(self) -> None:
+        dc = DiffCollector()
+        self._prime(dc)
+        assert (
+            dc.update(
+                "light.x",
+                [
+                    {"key": "on_off", "value": _v("bool", bool_value=True)},
+                    {"key": "light_brightness", "value": _v("integer", integer_value=50)},
+                ],
+            )
+            is None
+        )
+
+    def test_entries_without_key_are_ignored(self) -> None:
+        dc = DiffCollector()
+        self._prime(dc)
+        # A malformed state entry must not crash or corrupt the baseline —
+        # otherwise one bad payload poisons every future diff for the entity.
+        res = dc.update(
+            "light.x",
+            [
+                {"key": "on_off", "value": _v("bool", bool_value=True)},
+                {"value": _v("integer", integer_value=99)},  # no "key"
+                {"key": "light_brightness", "value": _v("integer", integer_value=50)},
+            ],
+        )
+        assert res is None
+
+
+class TestBaselineLifecycle:
+    """Baseline reset + per-entity isolation."""
+
+    def test_reset_entity_makes_next_update_initial(self) -> None:
+        dc = DiffCollector(include_initial=True)
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        dc.reset_entity("light.x")
+        res = dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        assert res is not None
+        assert res.is_initial is True
+
+    def test_entities_have_independent_baselines(self) -> None:
+        # Cross-pollination between entities would be a catastrophic
+        # bug — the diff for light.x must never reflect changes to light.y.
+        dc = DiffCollector()
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        dc.update("light.y", [{"key": "on_off", "value": _v("bool", bool_value=False)}])
+        res = dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=False)}])
+        assert res is not None
+        assert res.changed["on_off"]["before"] == _v("bool", bool_value=True)
+
+    def test_get_last_state_returns_deep_copy(self) -> None:
+        dc = DiffCollector()
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        snap = dc.get_last_state("light.x")
+        assert snap is not None
+        snap["on_off"]["bool_value"] = False
+        # Mutating the returned snapshot must not leak back into the collector.
+        assert dc.get_last_state("light.x")["on_off"]["bool_value"] is True
+
+
+class TestRecordPublishPayload:
+    """Entry point wired into the bridge publish path."""
+
+    def test_parses_json_string(self) -> None:
+        dc = DiffCollector(include_initial=True)
+        payload = json.dumps(
+            {
+                "devices": {
+                    "light.x": {
+                        "states": [
+                            {"key": "on_off", "value": _v("bool", bool_value=True)},
+                        ],
+                    },
+                    "switch.y": {
+                        "states": [
+                            {"key": "on_off", "value": _v("bool", bool_value=False)},
+                        ],
+                    },
+                }
+            }
+        )
+        diffs = dc.record_publish_payload(payload, topic="up/status")
+        assert {d.entity_id for d in diffs} == {"light.x", "switch.y"}
+
+    def test_accepts_pre_parsed_dict(self) -> None:
+        dc = DiffCollector(include_initial=True)
+        data = {"devices": {"light.x": {"states": [{"key": "on_off", "value": {}}]}}}
+        assert len(dc.record_publish_payload(data)) == 1
+
+    def test_invalid_json_returns_empty_without_raising(self) -> None:
+        # A publish with unexpected shape must not break the bridge.
+        dc = DiffCollector()
+        assert dc.record_publish_payload("not json") == []
+        assert dc.record_publish_payload("{}") == []
+        assert dc.record_publish_payload({"devices": "nope"}) == []  # type: ignore[arg-type]
+
+    def test_device_without_states_list_is_skipped(self) -> None:
+        dc = DiffCollector(include_initial=True)
+        payload = {"devices": {"ghost": {"name": "noop"}, "light.x": {"states": []}}}
+        # "ghost" has no states — must be skipped silently.
+        diffs = dc.record_publish_payload(payload)
+        assert diffs == []
+
+
+class TestSubscribers:
+    def test_subscriber_receives_only_non_empty_diffs(self) -> None:
+        dc = DiffCollector()
+        received: list[StateDiff] = []
+        dc.subscribe(received.append)
+        # Prime — no initial emission by default.
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        assert received == []
+        # Real change — one event.
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=False)}])
+        # No change — still one event.
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=False)}])
+        assert len(received) == 1
+
+    def test_unsubscribe_stops_delivery(self) -> None:
+        dc = DiffCollector()
+        received: list[StateDiff] = []
+        unsub = dc.subscribe(received.append)
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=False)}])
+        unsub()
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        assert len(received) == 1
+
+    def test_subscriber_exception_does_not_break_collector(self) -> None:
+        dc = DiffCollector()
+
+        def bad(_d: StateDiff) -> None:
+            raise RuntimeError("boom")
+
+        dc.subscribe(bad)
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        # Update that would fire subscribers — must not raise.
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=False)}])
+
+
+class TestRingBuffer:
+    def test_maxlen_enforced(self) -> None:
+        dc = DiffCollector(maxlen=3)
+        for i in range(5):
+            dc.update(
+                f"light.{i}",
+                [{"key": "on_off", "value": _v("bool", bool_value=True)}],
+            )
+            dc.update(
+                f"light.{i}",
+                [{"key": "on_off", "value": _v("bool", bool_value=False)}],
+            )
+        # Only 5 *real* diffs were generated (one per entity) and the
+        # ring buffer must trim to 3.
+        assert len(dc.snapshot()) == 3
+
+    def test_resize_shrinks_keeping_newest(self) -> None:
+        dc = DiffCollector(maxlen=10)
+        for i in range(4):
+            dc.update(
+                "light.x",
+                [{"key": "on_off", "value": _v("bool", bool_value=i % 2 == 0)}],
+            )
+        dc.resize(2)
+        assert len(dc.snapshot()) == 2
+
+    def test_clear_resets_everything(self) -> None:
+        dc = DiffCollector()
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=False)}])
+        dc.clear()
+        assert dc.snapshot() == []
+        # Baseline must go with the clear — otherwise first next update
+        # would be a phantom "changed" against the cleared history.
+        assert dc.get_last_state("light.x") is None
+
+
+class TestSerialization:
+    def test_diff_as_dict_is_json_serializable(self) -> None:
+        dc = DiffCollector()
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=True)}])
+        dc.update("light.x", [{"key": "on_off", "value": _v("bool", bool_value=False)}])
+        data = json.dumps(dc.snapshot())
+        # Field names must stay stable — UI reads them directly.
+        assert '"entity_id"' in data
+        assert '"changed"' in data
+        assert '"before"' in data
+        assert '"after"' in data

--- a/tests/hacs/test_state_diff_integration.py
+++ b/tests/hacs/test_state_diff_integration.py
@@ -1,0 +1,119 @@
+"""End-to-end tests: a Sber command → publish path produces state diffs.
+
+Guards the single important promise of this module at the bridge
+level: every outbound publish that changes a device's Sber-visible
+state registers a non-empty diff in ``bridge.diff_collector``.  A
+missing diff here means DevTools will never surface what actually
+changed between two publishes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.sber_mqtt_bridge.const import (
+    CONF_SBER_BROKER,
+    CONF_SBER_LOGIN,
+    CONF_SBER_PASSWORD,
+    CONF_SBER_PORT,
+)
+from custom_components.sber_mqtt_bridge.devices.relay import RelayEntity
+from custom_components.sber_mqtt_bridge.sber_bridge import SberBridge
+
+
+def _entry():
+    entry = MagicMock()
+    entry.data = {
+        CONF_SBER_LOGIN: "test",
+        CONF_SBER_PASSWORD: "pass",
+        CONF_SBER_BROKER: "broker.test",
+        CONF_SBER_PORT: 8883,
+    }
+    entry.options = {}
+    return entry
+
+
+def _hass():
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.config.location_name = "My Home"
+    tasks: list[asyncio.Task] = []
+
+    def capture(coro, **_):
+        t = asyncio.ensure_future(coro)
+        tasks.append(t)
+        return t
+
+    hass.async_create_task = MagicMock(side_effect=capture)
+    hass._created_tasks = tasks
+    return hass
+
+
+def _relay_bridge(hass):
+    bridge = SberBridge(hass, _entry())
+    bridge._mqtt_client = AsyncMock()
+    bridge._mqtt_service.publish = AsyncMock()
+    bridge._connected = True
+    bridge._ack_audit.cancel()
+    rel = RelayEntity({"entity_id": "switch.lamp", "name": "Lamp"})
+    rel.fill_by_ha_state({"entity_id": "switch.lamp", "state": "off", "attributes": {}})
+    bridge._entities["switch.lamp"] = rel
+    bridge._enabled_entity_ids = ["switch.lamp"]
+    return bridge
+
+
+async def _drain(hass):
+    for t in list(getattr(hass, "_created_tasks", [])):
+        if not t.done():
+            with contextlib.suppress(TimeoutError, Exception):
+                await asyncio.wait_for(t, timeout=5)
+
+
+class TestPublishProducesDiffs:
+    async def test_state_change_between_publishes_is_recorded(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        # First publish seeds the baseline (default: initial publish is silent).
+        await bridge._publish_states(["switch.lamp"], force=True)
+        await _drain(hass)
+        assert bridge.diff_collector.snapshot() == []
+
+        # Flip the HA state — every subsequent publish must carry the
+        # new value, and the diff collector must notice.
+        bridge._entities["switch.lamp"].fill_by_ha_state({"entity_id": "switch.lamp", "state": "on", "attributes": {}})
+        await bridge._publish_states(["switch.lamp"], force=True)
+        await _drain(hass)
+
+        diffs = bridge.diff_collector.snapshot()
+        # Exactly one diff — the "on_off False → True" transition.  Missing
+        # this is precisely the regression DevTools must not ship with.
+        assert len(diffs) == 1
+        d = diffs[0]
+        assert d["entity_id"] == "switch.lamp"
+        assert "on_off" in d["changed"]
+        assert d["changed"]["on_off"]["before"]["bool_value"] is False
+        assert d["changed"]["on_off"]["after"]["bool_value"] is True
+
+    async def test_no_state_change_produces_no_diff(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        # Prime the baseline.
+        await bridge._publish_states(["switch.lamp"], force=True)
+        before = len(bridge.diff_collector.snapshot())
+        # Another publish with the same state must not create a diff —
+        # otherwise the UI would spam identical entries every republish cycle.
+        await bridge._publish_states(["switch.lamp"], force=True)
+        assert len(bridge.diff_collector.snapshot()) == before
+
+
+class TestDiffCollectorExposedOnBridge:
+    def test_bridge_exposes_diff_collector_property(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        # WS handlers reach the collector through this one attribute.
+        # Renaming it would silently break the panel.
+        assert bridge.diff_collector is not None
+        assert bridge.diff_collector.snapshot() == []

--- a/tests/hacs/test_websocket_state_diffs.py
+++ b/tests/hacs/test_websocket_state_diffs.py
@@ -1,0 +1,94 @@
+"""Tests for the state-diff WebSocket commands.
+
+Protect the contract between the DevTools panel and the bridge: the
+payload shape (``diffs``, ``diff``, ``snapshot``) and error codes are
+what the UI reads directly.  A silent rename here breaks the panel
+with no pytest failure elsewhere.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.sber_mqtt_bridge.state_diff import DiffCollector
+from custom_components.sber_mqtt_bridge.websocket_api.diffs import (
+    ws_clear_state_diffs,
+    ws_list_state_diffs,
+    ws_subscribe_state_diffs,
+)
+
+
+@pytest.fixture
+def connection():
+    conn = MagicMock()
+    conn.send_result = MagicMock()
+    conn.send_error = MagicMock()
+    conn.send_message = MagicMock()
+    conn.subscriptions = {}
+    return conn
+
+
+@pytest.fixture
+def hass():
+    return MagicMock()
+
+
+def _prime_bridge_with_diff() -> MagicMock:
+    bridge = MagicMock()
+    bridge.diff_collector = DiffCollector(include_initial=True)
+    bridge.diff_collector.update("light.x", [{"key": "on_off", "value": {"type": "BOOL", "bool_value": True}}])
+    return bridge
+
+
+class TestListStateDiffs:
+    def test_returns_snapshot(self, hass, connection):
+        bridge = _prime_bridge_with_diff()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.diffs.get_bridge",
+            return_value=bridge,
+        ):
+            ws_list_state_diffs(hass, connection, {"id": 1})
+        payload = connection.send_result.call_args[0][1]
+        assert "diffs" in payload
+        assert payload["diffs"][0]["entity_id"] == "light.x"
+
+    def test_missing_bridge_sends_error(self, hass, connection):
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.diffs.get_bridge",
+            return_value=None,
+        ):
+            ws_list_state_diffs(hass, connection, {"id": 1})
+        connection.send_error.assert_called_once()
+
+
+class TestClearStateDiffs:
+    def test_clears_collector(self, hass, connection):
+        bridge = _prime_bridge_with_diff()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.diffs.get_bridge",
+            return_value=bridge,
+        ):
+            ws_clear_state_diffs(hass, connection, {"id": 2})
+        assert bridge.diff_collector.snapshot() == []
+
+
+class TestSubscribeStateDiffs:
+    def test_subscribe_sends_snapshot_then_live_updates(self, hass, connection):
+        bridge = _prime_bridge_with_diff()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.diffs.get_bridge",
+            return_value=bridge,
+        ):
+            ws_subscribe_state_diffs(hass, connection, {"id": 3})
+            # A subsequent real change must reach the subscriber.
+            bridge.diff_collector.update(
+                "light.x",
+                [{"key": "on_off", "value": {"type": "BOOL", "bool_value": False}}],
+            )
+
+        # One initial snapshot + one live diff.
+        assert connection.send_message.call_count >= 2
+        # Subscription tracked for HA auto-unsub on disconnect.
+        assert 3 in connection.subscriptions


### PR DESCRIPTION
## Summary

Second of five planned DevTools features. For every outbound Sber state
publish, computes a per-device delta against the previously-published
snapshot and stores **only what actually changed** — dropping the
repetitive 99 % of every payload that's identical to last time.

Sber state payloads re-send every feature of every affected device on
every publish (they have no protocol-level diff), so the raw MQTT log
buries the real change in noise. This view turns every publish into at
most a handful of rows:

```
light.kitchen
  ~ light_brightness : 50 → 75
  + light_colour     : h=0 s=100 v=100
  − on_off
```

Empty deltas are suppressed entirely, so the log only surfaces publishes
that matter.

## Architecture

- **`state_diff.py`** — `DiffCollector` with in-memory ring buffer,
  per-entity baseline (`_last_by_entity`), subscribe fan-out, and the
  convenience `record_publish_payload()` entry point (parses the
  already-serialized JSON so the publish path stays untouched).
- **Integration:** `SberBridge._publish_states` calls
  `record_publish_payload()` after a successful publish, wrapped in a
  guard so a DevTools failure can never break the publish path.
- **Settings:** `apply_settings` resizes the diff buffer alongside the
  message log.
- **WebSocket API (3 commands):** `state_diffs`, `clear_state_diffs`,
  `subscribe_state_diffs`.
- **UI:** new `sber-state-diff.js` component in the DevTools tab —
  colour-coded `+` / `−` / `~` rows with human-readable rendering of
  Sber `BOOL` / `INTEGER` / `DOUBLE` / `STRING` / `ENUM` / `COLOUR`
  values.

## Design choices worth noting

- **Initial publish silent by default.** First publish for each entity
  establishes a baseline without emitting a record — startup otherwise
  floods the view with "added" rows no one cares about.  Opt-in via
  `include_initial=True`.
- **Baseline reset on `clear()`.** Otherwise the first post-clear
  publish would emit a phantom "changed" against stale history.
- **Invalid JSON / bad shape returns `[]`.** A DevTools parse error must
  never propagate — the bridge doesn't care that we couldn't diff.

## Test plan

- [x] `pytest tests/hacs/` → 1828 passed (29 new: 22 unit, 3
      integration, 4 WS)
- [x] `ruff check` clean on changed files
- [x] `ruff format` clean
- [x] Snapshots updated for v1.33.0 (both `__snapshots__/` and legacy
      `snapshots/`)
- [ ] Manual: open DevTools, toggle a light twice, confirm exactly one
      diff row per real change with before/after values

🤖 Generated with [Claude Code](https://claude.com/claude-code)