### PR TITLE
feat: DevTools replay / inject (v1.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.34.0] - 2026-04-22
+
+### Added
+
+- **DevTools: Replay / Inject** — кнопка «Replay» на каждой входящей
+  записи MQTT-лога возвращает тот же payload обратно в диспетчер
+  моста так, будто Sber прислал его снова. Сетевой round-trip не
+  происходит, работает и в offline — тот же `SberCommandDispatcher`,
+  тот же correlation trace, тот же state diff, тот же ack audit.
+  Рядом — ручной JSON-editor с выбором topic suffix
+  (`commands` / `status_request` / `config_request` / `errors` /
+  `change_group` / `rename_device`) для инъекции произвольной
+  команды. Синтетический трафик помечается в логе
+  `direction="replay"`, чтобы UI не предлагал «реплеить реплей» и
+  не зацикливал пользователя. Новые компоненты:
+  - `SberBridge.async_inject_sber_message(topic, payload, *,
+    mark_replay=True)` — публичный entrypoint, роутит через
+    существующий `_mqtt_dispatch`.
+  - WebSocket API: `sber_mqtt_bridge/inject_sber_message`,
+    `.../replay_message`.
+  - UI-компонент `sber-replay.js` во вкладке DevTools — manual
+    inject form + список последних 15 incoming сообщений с кнопкой
+    Replay.
+
 ## [1.33.0] - 2026-04-22
 
 ### Added

--- a/custom_components/sber_mqtt_bridge/manifest.json
+++ b/custom_components/sber_mqtt_bridge/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dzerik/sber-mqtt-bridge/issues",
   "loggers": ["aiomqtt"],
   "requirements": ["aiomqtt>=2.0,<3.0", "pydantic>=2.0,<3.0"],
-  "version": "1.33.0"
+  "version": "1.34.0"
 }

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -485,6 +485,61 @@ class SberBridge:
         self._stats.messages_sent += 1
         self._log_message("out", topic, payload)
 
+    async def async_inject_sber_message(
+        self,
+        topic: str,
+        payload: str | bytes,
+        *,
+        mark_replay: bool = True,
+    ) -> dict[str, Any]:
+        """Feed a synthetic message into the dispatcher as if Sber sent it.
+
+        Used by DevTools Replay / Inject: takes a topic (full
+        ``sbdev/.../down/commands`` or a bare suffix like ``commands``)
+        and runs it through the normal inbound pipeline —
+        :class:`SberCommandDispatcher`, correlation trace, state diff,
+        ack audit — without going through the MQTT broker.  No network
+        round-trip means an injected command flows even when the bridge
+        is offline, which is exactly what users want when debugging.
+
+        Args:
+            topic: Either the full MQTT topic as it would arrive from
+                Sber cloud, or just the last segment (suffix) which is
+                automatically expanded to ``{root}/down/{suffix}``.
+            payload: Raw JSON body.  Bytes pass through as-is; strings
+                are UTF-8 encoded to match the real on-wire shape.
+            mark_replay: When True (default), the DevTools message log
+                records the direction as ``"replay"`` instead of
+                ``"in"`` so the UI can visually distinguish synthetic
+                traffic from real Sber commands.  Set False to make
+                the injection indistinguishable from real MQTT input
+                (e.g. reproducing a bug for screenshot).
+
+        Returns:
+            Dict with ``{"topic": str, "handled": bool, "suffix": str}``.
+            ``handled`` is False only when no dispatcher was registered
+            for the given suffix (unknown topic).
+        """
+        full_topic = topic if "/" in topic else f"{self._down_topic}/{topic}"
+        body = payload.encode("utf-8") if isinstance(payload, str) else payload
+
+        # Route through the dispatch table used by the real MQTT handler.
+        suffix = full_topic.rsplit("/", 1)[-1] if "/" in full_topic else full_topic
+        decoded = body.decode("utf-8", errors="replace")
+        self._log_message("replay" if mark_replay else "in", full_topic, decoded)
+
+        if full_topic == SBER_GLOBAL_CONFIG_TOPIC:
+            self._handle_global_config(body)
+            return {"topic": full_topic, "handled": True, "suffix": "(global_config)"}
+
+        handler = self._mqtt_dispatch.get(suffix)
+        if handler is None:
+            _LOGGER.warning("Inject: unhandled topic suffix %r", suffix)
+            return {"topic": full_topic, "handled": False, "suffix": suffix}
+
+        await handler(body)
+        return {"topic": full_topic, "handled": True, "suffix": suffix}
+
     # ---------------------------------------------------------------------------
     # Message log subscriber management (for real-time DevTools push)
     # ---------------------------------------------------------------------------

--- a/custom_components/sber_mqtt_bridge/sber_protocol.py
+++ b/custom_components/sber_mqtt_bridge/sber_protocol.py
@@ -15,7 +15,7 @@ from .sber_models import validate_config_payload, validate_device, validate_stat
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = "1.33.0"
+VERSION = "1.34.0"
 """Protocol version string included in the hub device descriptor."""
 
 

--- a/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
@@ -17,6 +17,7 @@ modules to keep per-file size and concerns focused:
 - ``log``             — message_log / clear_message_log / subscribe_messages
 - ``traces``          — correlation-timeline traces (DevTools #1)
 - ``diffs``           — state-payload diffs (DevTools #2)
+- ``replay``          — replay / inject Sber messages (DevTools #3)
 
 All public ``ws_*`` command functions are re-exported at package level
 for test introspection.
@@ -47,6 +48,7 @@ from .io_export import ws_export, ws_import, ws_update_redefinitions
 from .links import ws_auto_link_all, ws_set_entity_links
 from .log import ws_clear_message_log, ws_message_log, ws_subscribe_messages
 from .raw import ws_raw_config, ws_raw_states, ws_send_raw_config, ws_send_raw_state
+from .replay import ws_inject_sber_message, ws_replay_message
 from .settings import ws_get_settings, ws_update_settings
 from .status import (
     ws_device_detail,
@@ -77,6 +79,7 @@ __all__ = [
     "ws_get_status",
     "ws_get_trace",
     "ws_import",
+    "ws_inject_sber_message",
     "ws_list_categories",
     "ws_list_devices_for_category",
     "ws_list_state_diffs",
@@ -87,6 +90,7 @@ __all__ = [
     "ws_raw_states",
     "ws_related_sensors",
     "ws_remove_entities",
+    "ws_replay_message",
     "ws_republish",
     "ws_send_raw_config",
     "ws_send_raw_state",
@@ -143,6 +147,9 @@ _COMMANDS = (
     ws_list_state_diffs,
     ws_clear_state_diffs,
     ws_subscribe_state_diffs,
+    # DevTools replay / inject (v1.34.0)
+    ws_inject_sber_message,
+    ws_replay_message,
     # Settings
     ws_get_settings,
     ws_update_settings,

--- a/custom_components/sber_mqtt_bridge/websocket_api/replay.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/replay.py
@@ -1,0 +1,89 @@
+"""Replay / inject WebSocket commands (DevTools #3).
+
+Forwards a synthetic Sber-shaped MQTT payload into the bridge's
+dispatch table without touching the real broker.  The same pipeline
+that handles live Sber traffic — :class:`SberCommandDispatcher`,
+correlation traces, state diffs, ack audit — sees the injected
+message indistinguishably from a real one (except for the
+``direction="replay"`` marker in the message log, which the UI uses
+to tint synthetic rows).
+
+Two commands:
+    * ``inject_sber_message`` — arbitrary ``{"topic", "payload"}``.
+    * ``replay_message`` — convenience wrapper for re-sending an entry
+      directly from the message log (log rows carry both fields, but
+      the UI then has to know to re-encode; this is a thin alias so
+      the UI can stay declarative).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+
+from ._common import get_bridge
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/inject_sber_message",
+        vol.Required("topic"): str,
+        vol.Required("payload"): str,
+        vol.Optional("mark_replay", default=True): bool,
+    }
+)
+@websocket_api.async_response
+async def ws_inject_sber_message(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Inject a synthetic Sber message into the bridge dispatch table."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    try:
+        result = await bridge.async_inject_sber_message(msg["topic"], msg["payload"], mark_replay=msg["mark_replay"])
+    except (
+        ValueError,
+        RuntimeError,
+        TypeError,
+    ) as e:
+        # Explicit error channel — otherwise the UI sees a generic
+        # timeout and the user has no idea why the inject silently failed.
+        connection.send_error(msg["id"], "inject_failed", str(e))
+        return
+    connection.send_result(msg["id"], result)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/replay_message",
+        vol.Required("topic"): str,
+        vol.Required("payload"): str,
+    }
+)
+@websocket_api.async_response
+async def ws_replay_message(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Re-send a previously-captured Sber message (marked as replay)."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    try:
+        result = await bridge.async_inject_sber_message(msg["topic"], msg["payload"], mark_replay=True)
+    except (ValueError, RuntimeError, TypeError) as e:
+        connection.send_error(msg["id"], "replay_failed", str(e))
+        return
+    connection.send_result(msg["id"], result)

--- a/custom_components/sber_mqtt_bridge/www/components/sber-replay.js
+++ b/custom_components/sber_mqtt_bridge/www/components/sber-replay.js
@@ -1,0 +1,342 @@
+/**
+ * Sber MQTT Bridge — replay / inject Sber messages (DevTools #3).
+ *
+ * Two modes, one component:
+ *
+ *  1. Manual inject — textarea for the full payload + topic suffix
+ *     selector (commands / status_request / config_request / ...).
+ *  2. Replay from log — subscribes to the message log, shows the last
+ *     N incoming messages with a "Replay" button on each.  Click it
+ *     and the bridge feeds that exact payload back into its own
+ *     dispatcher as if Sber had re-sent it — no network round-trip,
+ *     works offline.
+ *
+ * Synthetic traffic is tagged with ``direction="replay"`` in the
+ * message log (see :meth:`async_inject_sber_message`) so replays
+ * never feed themselves in a loop.
+ */
+
+const LitElement = Object.getPrototypeOf(
+  customElements.get("ha-panel-lovelace") ?? customElements.get("hui-view")
+);
+const html = LitElement?.prototype.html;
+const css = LitElement?.prototype.css;
+
+const TOPIC_SUFFIXES = [
+  "commands",
+  "status_request",
+  "config_request",
+  "errors",
+  "change_group",
+  "rename_device",
+];
+
+const DEFAULT_PAYLOAD = JSON.stringify(
+  {
+    devices: {
+      "switch.example": {
+        states: [
+          { key: "on_off", value: { type: "BOOL", bool_value: true } },
+        ],
+      },
+    },
+  },
+  null,
+  2
+);
+
+class SberReplay extends LitElement {
+  static get properties() {
+    return {
+      hass: { type: Object },
+      _messages: { type: Array },
+      _topic: { type: String },
+      _payload: { type: String },
+      _busy: { type: Boolean },
+      _status: { type: String },
+      _statusKind: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this._messages = [];
+    this._topic = "commands";
+    this._payload = DEFAULT_PAYLOAD;
+    this._busy = false;
+    this._status = "";
+    this._statusKind = "";
+    this._hassReady = false;
+    this._unsub = null;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribe();
+  }
+
+  updated(changedProps) {
+    if (changedProps.has("hass") && this.hass && !this._hassReady) {
+      this._hassReady = true;
+      this._subscribe();
+    }
+  }
+
+  async _subscribe() {
+    if (this._unsub) return;
+    try {
+      this._unsub = await this.hass.connection.subscribeMessage(
+        (event) => {
+          if (event.snapshot) {
+            this._messages = event.snapshot;
+          } else if (event.message) {
+            this._messages = [...this._messages, event.message];
+          }
+        },
+        { type: "sber_mqtt_bridge/subscribe_messages" }
+      );
+    } catch (e) {
+      this._setStatus(`Subscribe failed: ${e.message || e}`, "error");
+    }
+  }
+
+  _unsubscribe() {
+    if (this._unsub) {
+      this._unsub();
+      this._unsub = null;
+    }
+  }
+
+  _setStatus(text, kind = "info") {
+    this._status = text;
+    this._statusKind = kind;
+  }
+
+  async _inject() {
+    if (this._busy) return;
+    this._busy = true;
+    this._setStatus("Injecting...", "info");
+    try {
+      const result = await this.hass.callWS({
+        type: "sber_mqtt_bridge/inject_sber_message",
+        topic: this._topic,
+        payload: this._payload,
+        mark_replay: true,
+      });
+      this._setStatus(
+        result.handled
+          ? `Injected → ${result.suffix}`
+          : `Unknown topic suffix: ${result.suffix}`,
+        result.handled ? "success" : "warning"
+      );
+    } catch (e) {
+      this._setStatus(`Inject failed: ${e.message || e}`, "error");
+    } finally {
+      this._busy = false;
+    }
+  }
+
+  async _replayOne(topic, payload) {
+    if (this._busy) return;
+    this._busy = true;
+    this._setStatus("Replaying...", "info");
+    try {
+      const result = await this.hass.callWS({
+        type: "sber_mqtt_bridge/replay_message",
+        topic,
+        payload,
+      });
+      this._setStatus(
+        result.handled
+          ? `Replayed → ${result.suffix}`
+          : `Unknown topic: ${result.suffix}`,
+        result.handled ? "success" : "warning"
+      );
+    } catch (e) {
+      this._setStatus(`Replay failed: ${e.message || e}`, "error");
+    } finally {
+      this._busy = false;
+    }
+  }
+
+  _formatTime(ts) {
+    const d = new Date(ts * 1000);
+    return d.toLocaleTimeString("ru-RU", { hour12: false });
+  }
+
+  _truncate(s, n = 80) {
+    if (typeof s !== "string") s = String(s ?? "");
+    return s.length > n ? s.slice(0, n) + "…" : s;
+  }
+
+  render() {
+    // Only incoming real traffic is replayable — replays themselves
+    // should not appear in the list or users would chain replays.
+    const replayable = this._messages
+      .filter((m) => m.direction === "in")
+      .slice(-15)
+      .reverse();
+
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <h2>Replay &amp; Inject</h2>
+        </div>
+        <div class="hint">
+          Feed a Sber-shaped MQTT message into the bridge without touching the broker.  Works offline; the same dispatcher, correlation trace and state diff see it.
+        </div>
+        ${this._status ? html`<div class="status status-${this._statusKind}">${this._status}</div>` : ""}
+
+        <div class="subsection">
+          <h3>Manual inject</h3>
+          <div class="form-row">
+            <label>Topic suffix</label>
+            <select .value=${this._topic} @change=${(e) => { this._topic = e.target.value; }}>
+              ${TOPIC_SUFFIXES.map((s) => html`<option value="${s}">${s}</option>`)}
+            </select>
+          </div>
+          <textarea class="json-editor"
+            .value=${this._payload}
+            spellcheck="false"
+            @input=${(e) => { this._payload = e.target.value; }}
+            placeholder="Sber JSON payload..."></textarea>
+          <div class="btn-bar">
+            <button class="btn-primary"
+              ?disabled=${this._busy || !this._payload.trim()}
+              @click=${this._inject}>
+              ${this._busy ? "Working..." : "Inject"}
+            </button>
+            <button class="btn-secondary"
+              @click=${() => { this._payload = DEFAULT_PAYLOAD; }}>
+              Reset template
+            </button>
+          </div>
+        </div>
+
+        <div class="subsection">
+          <h3>Replay from log</h3>
+          ${replayable.length === 0
+            ? html`<div class="empty">No incoming messages yet. Real Sber traffic will appear here.</div>`
+            : html`
+              <table class="replay-table">
+                <thead>
+                  <tr>
+                    <th>Time</th>
+                    <th>Topic</th>
+                    <th>Payload</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${replayable.map((m) => html`
+                    <tr>
+                      <td class="t">${this._formatTime(m.time)}</td>
+                      <td class="topic" title="${m.topic}">${this._shortTopic(m.topic)}</td>
+                      <td class="payload" title="${m.payload}">${this._truncate(m.payload)}</td>
+                      <td>
+                        <button class="btn-secondary small"
+                          ?disabled=${this._busy}
+                          @click=${() => this._replayOne(m.topic, m.payload)}>
+                          Replay
+                        </button>
+                      </td>
+                    </tr>
+                  `)}
+                </tbody>
+              </table>
+            `}
+        </div>
+      </div>
+    `;
+  }
+
+  _shortTopic(topic) {
+    if (!topic) return "";
+    const idx = topic.indexOf("/down/");
+    return idx >= 0 ? topic.slice(idx + 1) : topic;
+  }
+
+  static get styles() {
+    return css`
+      .section {
+        background: var(--card-background-color);
+        border-radius: 8px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+      .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+      h2 { margin: 0; font-size: 1.1em; color: var(--primary-text-color); }
+      h3 { margin: 16px 0 8px; font-size: 0.95em; color: var(--primary-text-color); }
+      .hint { color: var(--secondary-text-color); font-size: 0.85em; margin-bottom: 12px; }
+      .status {
+        padding: 6px 10px;
+        border-radius: 4px;
+        margin-bottom: 12px;
+        font-size: 0.9em;
+        font-family: monospace;
+      }
+      .status-info { background: var(--secondary-background-color); color: var(--primary-text-color); }
+      .status-success { background: rgba(76, 175, 80, 0.12); color: var(--success-color, #4caf50); }
+      .status-warning { background: rgba(255, 152, 0, 0.12); color: var(--warning-color, #ff9800); }
+      .status-error { background: rgba(244, 67, 54, 0.12); color: var(--error-color, #f44336); }
+      .subsection { border-top: 1px solid var(--divider-color); padding-top: 8px; }
+      .form-row { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+      .form-row label { color: var(--secondary-text-color); font-size: 0.9em; }
+      select {
+        background: var(--primary-background-color);
+        color: var(--primary-text-color);
+        border: 1px solid var(--divider-color);
+        border-radius: 4px;
+        padding: 6px 8px;
+      }
+      .json-editor {
+        width: 100%;
+        min-height: 160px;
+        font-family: monospace;
+        font-size: 0.85em;
+        background: var(--primary-background-color);
+        color: var(--primary-text-color);
+        border: 1px solid var(--divider-color);
+        border-radius: 4px;
+        padding: 8px;
+        box-sizing: border-box;
+        resize: vertical;
+      }
+      .btn-bar { display: flex; gap: 8px; margin-top: 8px; }
+      .btn-primary {
+        background: var(--primary-color, #03a9f4);
+        color: white;
+        border: none;
+        border-radius: 4px;
+        padding: 6px 14px;
+        cursor: pointer;
+      }
+      .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+      .btn-secondary {
+        background: var(--secondary-background-color);
+        color: var(--primary-text-color);
+        border: 1px solid var(--divider-color);
+        border-radius: 4px;
+        padding: 6px 12px;
+        cursor: pointer;
+      }
+      .btn-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
+      .btn-secondary.small { padding: 2px 8px; font-size: 0.85em; }
+      .empty { color: var(--secondary-text-color); font-style: italic; padding: 12px; text-align: center; }
+      .replay-table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+      .replay-table th {
+        text-align: left;
+        padding: 6px 8px;
+        border-bottom: 1px solid var(--divider-color);
+        color: var(--secondary-text-color);
+        font-weight: 500;
+      }
+      .replay-table td { padding: 4px 8px; vertical-align: middle; }
+      .t { font-family: monospace; color: var(--secondary-text-color); width: 80px; }
+      .topic { font-family: monospace; width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .payload { font-family: monospace; color: var(--primary-text-color); }
+    `;
+  }
+}
+
+customElements.define("sber-replay", SberReplay);

--- a/custom_components/sber_mqtt_bridge/www/sber-panel.js
+++ b/custom_components/sber_mqtt_bridge/www/sber-panel.js
@@ -22,6 +22,7 @@ await Promise.all([
   import(`./components/sber-devtools.js${_q}`),
   import(`./components/sber-traces.js${_q}`),
   import(`./components/sber-state-diff.js${_q}`),
+  import(`./components/sber-replay.js${_q}`),
   import(`./components/sber-settings.js${_q}`),
   import(`./components/sber-link-dialog.js${_q}`),
 ]);
@@ -539,6 +540,7 @@ class SberMqttPanel extends LitElement {
       ></sber-devtools>
       <sber-traces .hass=${this.hass}></sber-traces>
       <sber-state-diff .hass=${this.hass}></sber-state-diff>
+      <sber-replay .hass=${this.hass}></sber-replay>
     `;
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sber-mqtt-bridge"
-version = "1.33.0"
+version = "1.34.0"
 description = "Sber Smart Home MQTT Bridge for Home Assistant"
 requires-python = ">=3.13"
 license = "MIT"

--- a/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
+++ b/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.33.0',
+        'hw_version': '1.34.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.33.0',
+        'sw_version': '1.34.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.33.0',
+        'hw_version': '1.34.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.33.0',
+        'sw_version': '1.34.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/snapshots/test_protocol_snapshots.ambr
+++ b/tests/hacs/snapshots/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.33.0',
+        'hw_version': '1.34.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.33.0',
+        'sw_version': '1.34.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.33.0',
+        'hw_version': '1.34.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.33.0',
+        'sw_version': '1.34.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/test_replay_inject.py
+++ b/tests/hacs/test_replay_inject.py
@@ -1,0 +1,243 @@
+"""Tests for replay / inject (DevTools #3).
+
+The injection path is the quickest way to turn a DevTools user into a
+DoS on themselves — a bug here could silently swallow a command, run
+it twice, or bypass the reconnect guard.  Tests guard the contract:
+
+* Injected payload lands in the real dispatcher → HA service gets
+  called exactly once.
+* The message log marks synthetic traffic with ``direction="replay"``
+  (or ``"in"`` when ``mark_replay=False``).
+* Correlation trace + state diff see the same event they'd see for
+  real MQTT traffic.
+* Unknown topic suffixes return ``handled=False`` instead of raising.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.sber_mqtt_bridge.const import (
+    CONF_SBER_BROKER,
+    CONF_SBER_LOGIN,
+    CONF_SBER_PASSWORD,
+    CONF_SBER_PORT,
+)
+from custom_components.sber_mqtt_bridge.devices.relay import RelayEntity
+from custom_components.sber_mqtt_bridge.sber_bridge import SberBridge
+
+
+def _entry():
+    entry = MagicMock()
+    entry.data = {
+        CONF_SBER_LOGIN: "test",
+        CONF_SBER_PASSWORD: "pass",
+        CONF_SBER_BROKER: "broker.test",
+        CONF_SBER_PORT: 8883,
+    }
+    entry.options = {}
+    return entry
+
+
+def _hass():
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.config.location_name = "My Home"
+    tasks: list[asyncio.Task] = []
+
+    def capture(coro, **_):
+        t = asyncio.ensure_future(coro)
+        tasks.append(t)
+        return t
+
+    hass.async_create_task = MagicMock(side_effect=capture)
+    hass._created_tasks = tasks
+    return hass
+
+
+def _relay_bridge(hass):
+    bridge = SberBridge(hass, _entry())
+    bridge._mqtt_client = AsyncMock()
+    bridge._mqtt_service.publish = AsyncMock()
+    bridge._connected = True
+    bridge._ack_audit.cancel()
+    rel = RelayEntity({"entity_id": "switch.lamp", "name": "Lamp"})
+    rel.fill_by_ha_state({"entity_id": "switch.lamp", "state": "off", "attributes": {}})
+    bridge._entities["switch.lamp"] = rel
+    bridge._enabled_entity_ids = ["switch.lamp"]
+    return bridge
+
+
+async def _drain(hass):
+    for t in list(getattr(hass, "_created_tasks", [])):
+        if not t.done():
+            with contextlib.suppress(TimeoutError, Exception):
+                await asyncio.wait_for(t, timeout=5)
+
+
+def _cmd_payload() -> str:
+    return json.dumps(
+        {
+            "devices": {
+                "switch.lamp": {
+                    "states": [
+                        {"key": "on_off", "value": {"type": "BOOL", "bool_value": True}},
+                    ],
+                }
+            }
+        }
+    )
+
+
+class TestInjectRoutesThroughDispatcher:
+    """An injected command must look identical to the real one downstream."""
+
+    async def test_injected_command_triggers_ha_service_call(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        await bridge.async_inject_sber_message("commands", _cmd_payload())
+        await _drain(hass)
+        # Without the service call, injection is worthless — the whole
+        # point is to replay command flow end-to-end.
+        hass.services.async_call.assert_called()
+        call = hass.services.async_call.call_args
+        assert call.kwargs["domain"] == "switch"
+        assert call.kwargs["service"] == "turn_on"
+
+    async def test_full_topic_and_suffix_both_work(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        # Suffix-only form — bridge expands to full {root}/down/commands.
+        res = await bridge.async_inject_sber_message("commands", _cmd_payload())
+        await _drain(hass)
+        assert res["handled"] is True
+        assert res["topic"].endswith("/down/commands")
+
+        full = f"{bridge._down_topic}/commands"
+        res2 = await bridge.async_inject_sber_message(full, _cmd_payload())
+        await _drain(hass)
+        assert res2["handled"] is True
+        assert res2["topic"] == full
+
+    async def test_injection_appears_in_correlation_trace(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        await bridge.async_inject_sber_message("commands", _cmd_payload())
+        await _drain(hass)
+        traces = bridge.trace_collector.snapshot()
+        # The trace must contain the sber_command event and at least
+        # one ha_service_call — otherwise DevTools would hide the
+        # consequences of the replay entirely.
+        assert traces, "no trace created by inject"
+        types = {e["type"] for e in traces[0]["events"]}
+        assert "sber_command" in types
+        assert "ha_service_call" in types
+
+
+class TestMessageLogMarking:
+    async def test_mark_replay_true_writes_replay_direction(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        await bridge.async_inject_sber_message("commands", _cmd_payload(), mark_replay=True)
+        await _drain(hass)
+        # The UI tints synthetic rows based on this field — losing it
+        # turns the log into a liar about what's real.
+        directions = [m["direction"] for m in bridge.message_log]
+        assert "replay" in directions
+
+    async def test_mark_replay_false_writes_in_direction(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        await bridge.async_inject_sber_message("commands", _cmd_payload(), mark_replay=False)
+        await _drain(hass)
+        directions = [m["direction"] for m in bridge.message_log]
+        assert "in" in directions
+        assert "replay" not in directions
+
+
+class TestErrorPaths:
+    async def test_unknown_suffix_returns_handled_false_without_raising(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        # Protocol typo must not take the bridge down — DevTools users
+        # type freely, and an uncaught exception here would reach HA
+        # logs as an error every time.
+        res = await bridge.async_inject_sber_message("nope", "{}")
+        assert res == {
+            "topic": f"{bridge._down_topic}/nope",
+            "handled": False,
+            "suffix": "nope",
+        }
+
+    async def test_bytes_payload_accepted(self) -> None:
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        # aiomqtt delivers bytes — the real pipeline must accept them
+        # too so "paste exactly what the broker delivered" works.
+        res = await bridge.async_inject_sber_message("commands", _cmd_payload().encode())
+        await _drain(hass)
+        assert res["handled"] is True
+
+
+class TestWebSocketHandlers:
+    """Smoke-test the two WS wrappers (inject + replay)."""
+
+    async def test_inject_ws_returns_handled_true(self) -> None:
+        from unittest.mock import patch
+
+        from custom_components.sber_mqtt_bridge.websocket_api.replay import (
+            ws_inject_sber_message,
+        )
+
+        hass = _hass()
+        bridge = _relay_bridge(hass)
+        connection = MagicMock()
+        connection.send_result = MagicMock()
+        connection.send_error = MagicMock()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.replay.get_bridge",
+            return_value=bridge,
+        ):
+            await ws_inject_sber_message.__wrapped__(
+                hass,
+                connection,
+                {
+                    "id": 1,
+                    "topic": "commands",
+                    "payload": _cmd_payload(),
+                    "mark_replay": True,
+                },
+            )
+            await _drain(hass)
+        payload = connection.send_result.call_args[0][1]
+        assert payload["handled"] is True
+        connection.send_error.assert_not_called()
+
+    async def test_replay_ws_missing_bridge_sends_error(self) -> None:
+        from unittest.mock import patch
+
+        from custom_components.sber_mqtt_bridge.websocket_api.replay import (
+            ws_replay_message,
+        )
+
+        hass = _hass()
+        connection = MagicMock()
+        connection.send_result = MagicMock()
+        connection.send_error = MagicMock()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.replay.get_bridge",
+            return_value=None,
+        ):
+            await ws_replay_message.__wrapped__(
+                hass,
+                connection,
+                {"id": 1, "topic": "commands", "payload": "{}"},
+            )
+        # A clear error code lets the UI tell the user "bridge not loaded"
+        # instead of a generic spinner timeout.
+        err = connection.send_error.call_args
+        assert err[0][1] == "bridge_not_found"


### PR DESCRIPTION
## Summary

Third of five DevTools features.  Feed a Sber-shaped MQTT payload into
the bridge dispatcher **without touching the real broker**.  Injected
messages flow through the exact same pipeline as live Sber traffic —
`SberCommandDispatcher`, correlation trace, state diff, ack audit —
and the only observable difference is a ``direction="replay"`` tag in
the DevTools message log so synthetic rows are visually distinct.

Works offline (no round-trip means replays succeed even when MQTT is
down), which is the most common state while debugging.

## Why this matters

Before: to reproduce a bug triggered by a specific Sber command, you
had to go back to the Салют app and repeat the voice/button sequence.
With replay, the "fixed it → test it" loop is a single click.

## New API

```python
async def async_inject_sber_message(
    self,
    topic: str,                # "commands" or full {root}/down/...
    payload: str | bytes,
    *,
    mark_replay: bool = True,  # direction tag in the message log
) -> dict                      # {"topic", "handled", "suffix"}
```

## WebSocket API (2 commands)

- `sber_mqtt_bridge/inject_sber_message` — arbitrary inject with
  optional ``mark_replay``.
- `sber_mqtt_bridge/replay_message` — convenience alias for re-sending
  a logged message (always marks as replay).

## UI

New `sber-replay.js` component in the DevTools tab:
- **Manual inject** — textarea with a default template + topic suffix
  dropdown (commands / status_request / config_request / errors /
  change_group / rename_device).
- **Replay from log** — subscribes to the existing message log and
  offers a "Replay" button on each of the last 15 incoming messages
  (`direction="in"` only — replays don't appear in the list to avoid
  accidental loops).

## Test plan

- [x] `pytest tests/hacs/` → 1837 passed (9 new covering: dispatcher
      routing, full-topic vs suffix, trace integration, message-log
      tagging, unknown suffix error path, bytes payload acceptance,
      both WS handlers)
- [x] `ruff check` and `ruff format` clean on all changed files
- [x] Snapshots bumped to v1.34.0 in both locations
- [ ] Manual: replay a captured Sber command from the DevTools log,
      confirm the trace/diff views populate as if the message had
      arrived live

🤖 Generated with [Claude Code](https://claude.com/claude-code)