### PR TITLE
feat: DevTools schema validation (v1.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.35.0] - 2026-04-22
+
+### Added
+
+- **DevTools: Schema Validation** — каждый исходящий state-publish
+  проверяется против авто-генерированной Sber-спецификации
+  (`_generated/feature_types.py`,
+  `_generated/obligatory_features.py`,
+  `_generated/category_features.py`), найденные проблемы попадают в
+  панель как actionable issues с severity. Четыре класса проверок:
+  - `missing_obligatory` (error) — не хватает feature из
+    обязательного списка category → Sber молча дропает устройство.
+  - `type_mismatch` (error) — `value.type` не совпадает с
+    `FEATURE_TYPES[key]` (например, `STRING` вместо `ENUM`).
+  - `unknown_for_category` (warning) — feature не в reference set
+    category.
+  - `not_declared` (info) — feature в payload, но не в
+    `features`-списке устройства.
+
+  Новые компоненты:
+  - `schema_validator.py` — pure-Python `validate_publish(...)` +
+    `ValidationCollector` с ring-buffer'ом и per-entity
+    latest-snapshot (чтобы UI мог и хронологически, и «что сломано
+    прямо сейчас»).
+  - Интеграция в `SberBridge._publish_states` — читает
+    `entity.category` и `entity.get_final_features_list()` из уже
+    загруженных entity'ов, не меняет publish-код.
+  - WebSocket API: `sber_mqtt_bridge/validation_issues`,
+    `.../clear_validation_issues`, `.../subscribe_validation_issues`.
+  - UI-компонент `sber-validation.js` во вкладке DevTools — две
+    вкладки (By entity / Timeline), счётчики errors/warnings/info,
+    цветные severity-badges.
+
 ## [1.34.0] - 2026-04-22
 
 ### Added

--- a/custom_components/sber_mqtt_bridge/manifest.json
+++ b/custom_components/sber_mqtt_bridge/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dzerik/sber-mqtt-bridge/issues",
   "loggers": ["aiomqtt"],
   "requirements": ["aiomqtt>=2.0,<3.0", "pydantic>=2.0,<3.0"],
-  "version": "1.34.0"
+  "version": "1.35.0"
 }

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -58,6 +58,7 @@ from .sber_protocol import (
     build_devices_list_json,
     build_states_list_json,
 )
+from .schema_validator import ValidationCollector
 from .state_diff import DiffCollector
 from .trace_collector import TraceCollector
 
@@ -262,6 +263,11 @@ class SberBridge:
         # "what actually changed" instead of the full repetitive payload.
         self._diff_collector = DiffCollector(maxlen=self._message_log_size)
 
+        # Schema validator (DevTools) — checks every outbound publish
+        # against the auto-generated Sber spec so users see silent
+        # rejections turn into explicit actionable issues.
+        self._validation_collector = ValidationCollector(maxlen=self._message_log_size)
+
     @property
     def is_connected(self) -> bool:
         """Return True if connected to Sber MQTT."""
@@ -459,6 +465,7 @@ class SberBridge:
         self._msg_logger.resize(self._message_log_size)
         self._trace_collector.resize(self._message_log_size)
         self._diff_collector.resize(self._message_log_size)
+        self._validation_collector.resize(self._message_log_size)
 
         _LOGGER.info(
             "Bridge settings applied (debounce=%.2fs, log=%d)",
@@ -572,6 +579,11 @@ class SberBridge:
     def diff_collector(self) -> DiffCollector:
         """Return the state-diff collector for WS API access."""
         return self._diff_collector
+
+    @property
+    def validation_collector(self) -> ValidationCollector:
+        """Return the schema-validation collector for WS API access."""
+        return self._validation_collector
 
     def _sweep_traces(self) -> None:
         """Close traces idle beyond the configured timeout.
@@ -1092,6 +1104,19 @@ class SberBridge:
             self._diff_collector.record_publish_payload(payload_str, topic=topic)
         except Exception:  # pragma: no cover — must never break publish
             _LOGGER.exception("DiffCollector.record_publish_payload failed")
+        # DevTools schema validation: check the payload against the Sber spec
+        # (obligatory features / feature types / unknown keys) so silent
+        # rejections become explicit actionable issues.
+        try:
+            categories = {eid: ent.category for eid, ent in self._entities.items()}
+            declared = {eid: ent.get_final_features_list() for eid, ent in self._entities.items()}
+            self._validation_collector.record_publish_payload(
+                payload_str,
+                categories=categories,
+                declared_features=declared,
+            )
+        except Exception:  # pragma: no cover — must never break publish
+            _LOGGER.exception("ValidationCollector.record_publish_payload failed")
 
     async def _publish_config(self, entity_ids: list[str] | None = None) -> None:
         """Publish device config to Sber MQTT."""

--- a/custom_components/sber_mqtt_bridge/sber_protocol.py
+++ b/custom_components/sber_mqtt_bridge/sber_protocol.py
@@ -15,7 +15,7 @@ from .sber_models import validate_config_payload, validate_device, validate_stat
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = "1.34.0"
+VERSION = "1.35.0"
 """Protocol version string included in the hub device descriptor."""
 
 

--- a/custom_components/sber_mqtt_bridge/schema_validator.py
+++ b/custom_components/sber_mqtt_bridge/schema_validator.py
@@ -1,0 +1,323 @@
+"""Sber state payload schema validator for DevTools.
+
+Validates every outgoing state publish against the auto-generated Sber
+spec (see ``_generated/``) and surfaces four kinds of issue:
+
+* **missing_obligatory** — a feature listed in
+  :data:`CATEGORY_OBLIGATORY_FEATURES` is not present in the payload.
+  Sber silently drops the device on the first such publish.
+* **unknown_for_category** — a feature key that isn't in the Sber
+  reference set for this category.  Often tolerated today but an
+  easy future breakage.
+* **type_mismatch** — the payload's ``value.type`` does not match
+  :data:`FEATURE_TYPES` for that key (e.g. sending ``INTEGER`` where
+  the spec declares ``BOOL``).  Reliable way to get silently rejected.
+* **not_declared** — the state's key isn't in the device's own
+  ``features`` list as published in the config, so Sber will refuse
+  to route the value.
+
+Each issue carries ``severity`` (``error`` / ``warning`` / ``info``),
+the ``entity_id`` and ``key``, and a short human-readable
+``description`` for DevTools to render.
+
+The collector keeps two views:
+
+* ``recent_issues`` — ring buffer of every issue emitted, newest
+  first, used for chronological scanning.
+* ``by_entity`` — latest-only per (entity_id, key, type) tuple, so
+  the UI can render a "current health of each entity" table.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+from ._generated.category_features import CATEGORY_REFERENCE_FEATURES
+from ._generated.feature_types import FEATURE_TYPES
+from ._generated.obligatory_features import CATEGORY_OBLIGATORY_FEATURES
+
+_LOGGER = logging.getLogger(__name__)
+
+IssueType = Literal[
+    "missing_obligatory",
+    "unknown_for_category",
+    "type_mismatch",
+    "not_declared",
+]
+Severity = Literal["error", "warning", "info"]
+
+_SEVERITY: dict[IssueType, Severity] = {
+    "missing_obligatory": "error",
+    "unknown_for_category": "warning",
+    "type_mismatch": "error",
+    "not_declared": "info",
+}
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """One validation problem found in a publish."""
+
+    ts: float
+    entity_id: str
+    category: str
+    type: IssueType
+    severity: Severity
+    key: str | None
+    description: str
+    details: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+def _value_type(value: Any) -> str | None:
+    """Extract the declared ``type`` field from a Sber value dict."""
+    if isinstance(value, dict):
+        t = value.get("type")
+        if isinstance(t, str):
+            return t
+    return None
+
+
+def validate_publish(
+    *,
+    entity_id: str,
+    category: str | None,
+    states: Iterable[dict[str, Any]],
+    declared_features: Iterable[str] | None = None,
+) -> list[ValidationIssue]:
+    """Classify every issue in one device's publish snapshot.
+
+    Args:
+        entity_id: HA entity id / Sber device id.
+        category: Sber category (e.g. ``"light"``, ``"hvac_ac"``).
+            Unknown categories short-circuit all spec-based checks
+            (we can't validate what we don't know) — those entities
+            only get the ``not_declared`` check.
+        states: The ``states`` list from the Sber payload, each
+            ``{"key": str, "value": {"type": ..., ...}}``.
+        declared_features: Feature names advertised by the device in
+            its config publish.  ``None`` skips the ``not_declared``
+            check (useful when the caller genuinely doesn't have the
+            info, e.g. synthetic payload).
+
+    Returns:
+        List of :class:`ValidationIssue`.  Empty list == clean publish.
+    """
+    now = time.time()
+    issues: list[ValidationIssue] = []
+    states_list = list(states)
+    state_keys = {s.get("key") for s in states_list if s.get("key")}
+
+    # --- missing obligatory -------------------------------------------------
+    if category in CATEGORY_OBLIGATORY_FEATURES:
+        issues.extend(
+            ValidationIssue(
+                ts=now,
+                entity_id=entity_id,
+                category=category,
+                type="missing_obligatory",
+                severity=_SEVERITY["missing_obligatory"],
+                key=must,
+                description=(
+                    f"Obligatory feature '{must}' for category "
+                    f"'{category}' is absent from the publish. "
+                    "Sber will drop this device."
+                ),
+                details={"missing": must},
+            )
+            for must in CATEGORY_OBLIGATORY_FEATURES[category]
+            if must not in state_keys
+        )
+
+    ref = CATEGORY_REFERENCE_FEATURES.get(category) if category else None
+    declared_set = set(declared_features) if declared_features is not None else None
+
+    for s in states_list:
+        key = s.get("key")
+        if not key:
+            continue
+        val = s.get("value")
+        actual_type = _value_type(val)
+
+        # --- type mismatch -------------------------------------------------
+        expected = FEATURE_TYPES.get(key)
+        if expected is not None and actual_type and actual_type != expected:
+            issues.append(
+                ValidationIssue(
+                    ts=now,
+                    entity_id=entity_id,
+                    category=category or "",
+                    type="type_mismatch",
+                    severity=_SEVERITY["type_mismatch"],
+                    key=key,
+                    description=(f"Feature '{key}' sent as {actual_type}, spec requires {expected}."),
+                    details={"expected": expected, "actual": actual_type},
+                )
+            )
+
+        # --- unknown for category -----------------------------------------
+        if ref is not None and key not in ref:
+            issues.append(
+                ValidationIssue(
+                    ts=now,
+                    entity_id=entity_id,
+                    category=category or "",
+                    type="unknown_for_category",
+                    severity=_SEVERITY["unknown_for_category"],
+                    key=key,
+                    description=(f"Feature '{key}' is not in Sber's reference set for category '{category}'."),
+                    details={},
+                )
+            )
+
+        # --- not in declared features -------------------------------------
+        if declared_set is not None and key not in declared_set:
+            issues.append(
+                ValidationIssue(
+                    ts=now,
+                    entity_id=entity_id,
+                    category=category or "",
+                    type="not_declared",
+                    severity=_SEVERITY["not_declared"],
+                    key=key,
+                    description=(
+                        f"Feature '{key}' is published but not advertised in the device's config features list."
+                    ),
+                    details={},
+                )
+            )
+
+    return issues
+
+
+class ValidationCollector:
+    """Stores recent validation issues with live subscribe fan-out.
+
+    Keeps two complementary views: a chronological ring buffer
+    (``recent_issues``) and a per-entity latest-snapshot
+    (``issues_by_entity``) so the UI can answer both "what was the
+    last problem" and "which entities are currently broken".
+    """
+
+    def __init__(self, maxlen: int = 500) -> None:
+        """Initialize a collector with the given ring-buffer capacity."""
+        self._recent: deque[ValidationIssue] = deque(maxlen=maxlen)
+        self._by_entity: dict[str, list[ValidationIssue]] = {}
+        self._subscribers: set[Callable[[list[ValidationIssue]], None]] = set()
+
+    @property
+    def maxlen(self) -> int | None:
+        """Return ring-buffer capacity."""
+        return self._recent.maxlen
+
+    def resize(self, new_maxlen: int) -> None:
+        """Resize the ring buffer keeping the newest entries."""
+        if new_maxlen == self._recent.maxlen:
+            return
+        old = list(self._recent)
+        self._recent = deque(old[-new_maxlen:], maxlen=new_maxlen)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-serializable snapshot of both views."""
+        return {
+            "recent": [i.as_dict() for i in self._recent],
+            "by_entity": {eid: [i.as_dict() for i in issues] for eid, issues in self._by_entity.items()},
+        }
+
+    def clear(self) -> None:
+        """Drop all stored issues."""
+        self._recent.clear()
+        self._by_entity.clear()
+
+    def record(self, entity_id: str, issues: list[ValidationIssue]) -> None:
+        """Persist the set of issues for ``entity_id`` after a publish.
+
+        A publish that fixes an entity's last error must overwrite the
+        per-entity snapshot so DevTools flips it from red to clean;
+        that's why we replace (not append) the per-entity list.
+        """
+        # Per-entity view — always overwrite; an empty list signals
+        # "entity is clean now", otherwise DevTools can never show the
+        # fix propagating.
+        self._by_entity[entity_id] = list(issues)
+        for i in issues:
+            self._recent.append(i)
+        if issues:
+            self._notify(issues)
+
+    def subscribe(self, callback_fn: Callable[[list[ValidationIssue]], None]) -> Callable[[], None]:
+        """Subscribe to validation bursts (one call per publish with issues)."""
+        self._subscribers.add(callback_fn)
+
+        def unsub() -> None:
+            self._subscribers.discard(callback_fn)
+
+        return unsub
+
+    def _notify(self, issues: list[ValidationIssue]) -> None:
+        for cb in list(self._subscribers):
+            try:
+                cb(issues)
+            except (RuntimeError, ValueError, TypeError, AttributeError):
+                _LOGGER.exception("ValidationCollector subscriber raised")
+
+    def record_publish_payload(
+        self,
+        payload: str | dict[str, Any],
+        *,
+        categories: dict[str, str] | None = None,
+        declared_features: dict[str, Iterable[str]] | None = None,
+    ) -> dict[str, list[ValidationIssue]]:
+        """Parse a full Sber publish payload and record per-device issues.
+
+        Args:
+            payload: JSON string or already-parsed dict.
+            categories: Optional mapping ``entity_id → sber_category``.
+                Entities without a known category skip spec checks.
+            declared_features: Optional mapping ``entity_id → features``
+                (as published in the config).  Enables the
+                ``not_declared`` check.
+
+        Returns:
+            ``entity_id → [issues]`` — empty list for clean devices.
+            Malformed input returns an empty dict without raising.
+        """
+        if isinstance(payload, str):
+            try:
+                import json
+
+                data = json.loads(payload)
+            except (ValueError, TypeError):
+                return {}
+        else:
+            data = payload
+        devices = data.get("devices") if isinstance(data, dict) else None
+        if not isinstance(devices, dict):
+            return {}
+
+        result: dict[str, list[ValidationIssue]] = {}
+        categories = categories or {}
+        declared_features = declared_features or {}
+        for eid, body in devices.items():
+            if not isinstance(body, dict):
+                continue
+            states = body.get("states")
+            if not isinstance(states, list):
+                continue
+            issues = validate_publish(
+                entity_id=eid,
+                category=categories.get(eid),
+                states=states,
+                declared_features=declared_features.get(eid),
+            )
+            self.record(eid, issues)
+            result[eid] = issues
+        return result

--- a/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
@@ -18,6 +18,7 @@ modules to keep per-file size and concerns focused:
 - ``traces``          — correlation-timeline traces (DevTools #1)
 - ``diffs``           — state-payload diffs (DevTools #2)
 - ``replay``          — replay / inject Sber messages (DevTools #3)
+- ``validation``      — Sber schema validation issues (DevTools #4)
 
 All public ``ws_*`` command functions are re-exported at package level
 for test introspection.
@@ -59,6 +60,11 @@ from .status import (
     ws_republish,
 )
 from .traces import ws_clear_traces, ws_get_trace, ws_list_traces, ws_subscribe_traces
+from .validation import (
+    ws_clear_validation_issues,
+    ws_list_validation_issues,
+    ws_subscribe_validation_issues,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +78,7 @@ __all__ = [
     "ws_clear_message_log",
     "ws_clear_state_diffs",
     "ws_clear_traces",
+    "ws_clear_validation_issues",
     "ws_device_detail",
     "ws_export",
     "ws_get_devices",
@@ -84,6 +91,7 @@ __all__ = [
     "ws_list_devices_for_category",
     "ws_list_state_diffs",
     "ws_list_traces",
+    "ws_list_validation_issues",
     "ws_message_log",
     "ws_publish_one_status",
     "ws_raw_config",
@@ -99,6 +107,7 @@ __all__ = [
     "ws_subscribe_messages",
     "ws_subscribe_state_diffs",
     "ws_subscribe_traces",
+    "ws_subscribe_validation_issues",
     "ws_suggest_links",
     "ws_update_redefinitions",
     "ws_update_settings",
@@ -150,6 +159,10 @@ _COMMANDS = (
     # DevTools replay / inject (v1.34.0)
     ws_inject_sber_message,
     ws_replay_message,
+    # DevTools schema validation (v1.35.0)
+    ws_list_validation_issues,
+    ws_clear_validation_issues,
+    ws_subscribe_validation_issues,
     # Settings
     ws_get_settings,
     ws_update_settings,

--- a/custom_components/sber_mqtt_bridge/websocket_api/validation.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/validation.py
@@ -1,0 +1,96 @@
+"""Schema-validation WebSocket commands (DevTools #4).
+
+Frontend counterpart to
+:mod:`custom_components.sber_mqtt_bridge.schema_validator`.  Returns
+both the chronological ring buffer of issues and the latest-per-entity
+map so the UI can render "what happened" and "what is broken right
+now" without two round-trips.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+
+from ._common import get_bridge
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/validation_issues",
+    }
+)
+@callback
+def ws_list_validation_issues(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return the full snapshot (recent + by_entity)."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    connection.send_result(msg["id"], bridge.validation_collector.snapshot())
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/clear_validation_issues",
+    }
+)
+@callback
+def ws_clear_validation_issues(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Drop all recorded validation issues."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    bridge.validation_collector.clear()
+    connection.send_result(msg["id"], {"success": True})
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/subscribe_validation_issues",
+    }
+)
+@callback
+def ws_subscribe_validation_issues(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Stream validation bursts to the subscriber.
+
+    Sends the initial snapshot, then one event per publish that
+    produces issues.  A "clean" publish (no issues) does NOT trigger
+    an event — the per-entity snapshot is still updated but the UI
+    learns about it only on next re-fetch / subscribe.
+    """
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+
+    connection.send_result(msg["id"])
+    connection.send_message(
+        websocket_api.event_message(msg["id"], {"snapshot": bridge.validation_collector.snapshot()})
+    )
+
+    @callback
+    def forward(issues: list[Any]) -> None:
+        connection.send_message(websocket_api.event_message(msg["id"], {"issues": [i.as_dict() for i in issues]}))
+
+    unsub = bridge.validation_collector.subscribe(forward)
+    connection.subscriptions[msg["id"]] = unsub

--- a/custom_components/sber_mqtt_bridge/www/components/sber-validation.js
+++ b/custom_components/sber_mqtt_bridge/www/components/sber-validation.js
@@ -1,0 +1,316 @@
+/**
+ * Sber MQTT Bridge — schema validation issues (DevTools #4).
+ *
+ * Subscribes to ``sber_mqtt_bridge/subscribe_validation_issues`` and
+ * surfaces everything the validator finds in every outbound publish:
+ *
+ *   - Missing obligatory feature (error)   → Sber silently drops the device.
+ *   - Type mismatch (error)                → Sber rejects the value.
+ *   - Unknown feature for category (warn)  → Future-proof nudge.
+ *   - Not in declared features (info)      → Value never reaches Sber.
+ *
+ * Two-tab layout:
+ *
+ *   "By entity" — latest status per entity (clean vs issues).  Best
+ *                 for "which devices are broken right now".
+ *   "Timeline"  — chronological feed (newest first).  Best for "what
+ *                 happened during this debug session".
+ */
+
+const LitElement = Object.getPrototypeOf(
+  customElements.get("ha-panel-lovelace") ?? customElements.get("hui-view")
+);
+const html = LitElement?.prototype.html;
+const css = LitElement?.prototype.css;
+
+class SberValidation extends LitElement {
+  static get properties() {
+    return {
+      hass: { type: Object },
+      _byEntity: { type: Object },
+      _recent: { type: Array },
+      _tab: { type: String },
+      _error: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this._byEntity = {};
+    this._recent = [];
+    this._tab = "by_entity";
+    this._error = "";
+    this._hassReady = false;
+    this._unsub = null;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribe();
+  }
+
+  updated(changedProps) {
+    if (changedProps.has("hass") && this.hass && !this._hassReady) {
+      this._hassReady = true;
+      this._subscribe();
+    }
+  }
+
+  async _subscribe() {
+    if (this._unsub) return;
+    try {
+      this._unsub = await this.hass.connection.subscribeMessage(
+        (event) => {
+          if (event.snapshot) {
+            this._byEntity = event.snapshot.by_entity || {};
+            this._recent = event.snapshot.recent || [];
+          } else if (event.issues) {
+            // Live batch — append to timeline and re-group by entity.
+            const updated = { ...this._byEntity };
+            for (const issue of event.issues) {
+              updated[issue.entity_id] = (updated[issue.entity_id] || []).filter(
+                // Per-entity view holds only the latest batch for the entity —
+                // same contract as the server.
+                () => false
+              );
+            }
+            for (const issue of event.issues) {
+              (updated[issue.entity_id] ||= []).push(issue);
+            }
+            this._byEntity = updated;
+            this._recent = [...this._recent, ...event.issues];
+          }
+        },
+        { type: "sber_mqtt_bridge/subscribe_validation_issues" }
+      );
+    } catch (e) {
+      this._error = e.message || String(e);
+    }
+  }
+
+  _unsubscribe() {
+    if (this._unsub) {
+      this._unsub();
+      this._unsub = null;
+    }
+  }
+
+  async _clear() {
+    try {
+      await this.hass.callWS({ type: "sber_mqtt_bridge/clear_validation_issues" });
+      this._byEntity = {};
+      this._recent = [];
+      this._error = "";
+    } catch (e) {
+      this._error = e.message || String(e);
+    }
+  }
+
+  _formatTime(ts) {
+    const d = new Date(ts * 1000);
+    return d.toLocaleTimeString("ru-RU", { hour12: false });
+  }
+
+  _counts() {
+    let errors = 0;
+    let warnings = 0;
+    let infos = 0;
+    for (const list of Object.values(this._byEntity)) {
+      for (const i of list) {
+        if (i.severity === "error") errors++;
+        else if (i.severity === "warning") warnings++;
+        else infos++;
+      }
+    }
+    return { errors, warnings, infos };
+  }
+
+  render() {
+    const { errors, warnings, infos } = this._counts();
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <h2>Schema Validation</h2>
+          <div class="btn-group">
+            <button class="btn-danger"
+              ?disabled=${this._recent.length === 0}
+              @click=${this._clear}>
+              Clear
+            </button>
+          </div>
+        </div>
+        <div class="summary">
+          <span class="chip chip-error">${errors} errors</span>
+          <span class="chip chip-warning">${warnings} warnings</span>
+          <span class="chip chip-info">${infos} info</span>
+          <span class="hint">Every outbound publish is checked against the auto-generated Sber spec.</span>
+        </div>
+        ${this._error ? html`<div class="error-text">${this._error}</div>` : ""}
+        <div class="tabs">
+          <button class="tab ${this._tab === "by_entity" ? "active" : ""}"
+            @click=${() => { this._tab = "by_entity"; }}>
+            By entity
+          </button>
+          <button class="tab ${this._tab === "timeline" ? "active" : ""}"
+            @click=${() => { this._tab = "timeline"; }}>
+            Timeline
+          </button>
+        </div>
+        ${this._tab === "by_entity" ? this._renderByEntity() : this._renderTimeline()}
+      </div>
+    `;
+  }
+
+  _renderByEntity() {
+    const entities = Object.keys(this._byEntity).sort();
+    if (entities.length === 0) {
+      return html`<div class="empty">No publishes validated yet.</div>`;
+    }
+    return html`
+      <table class="issue-table">
+        <thead>
+          <tr>
+            <th class="col-entity">Entity</th>
+            <th class="col-sev"></th>
+            <th class="col-type">Issue</th>
+            <th class="col-key">Feature</th>
+            <th class="col-desc">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${entities.flatMap((eid) => {
+            const issues = this._byEntity[eid] || [];
+            if (issues.length === 0) {
+              return [html`
+                <tr class="clean">
+                  <td class="entity">${eid}</td>
+                  <td class="sev"><span class="badge badge-clean">clean</span></td>
+                  <td colspan="3">No issues</td>
+                </tr>
+              `];
+            }
+            return issues.map((i, idx) => html`
+              <tr class="sev-${i.severity}">
+                <td class="entity">${idx === 0 ? eid : ""}</td>
+                <td class="sev"><span class="badge badge-${i.severity}">${i.severity}</span></td>
+                <td class="type">${i.type}</td>
+                <td class="key">${i.key || "—"}</td>
+                <td class="desc">${i.description}</td>
+              </tr>
+            `);
+          })}
+        </tbody>
+      </table>
+    `;
+  }
+
+  _renderTimeline() {
+    const rows = [...this._recent].reverse();
+    if (rows.length === 0) {
+      return html`<div class="empty">No issues yet.</div>`;
+    }
+    return html`
+      <table class="issue-table">
+        <thead>
+          <tr>
+            <th class="col-time">Time</th>
+            <th class="col-entity">Entity</th>
+            <th class="col-sev"></th>
+            <th class="col-type">Issue</th>
+            <th class="col-key">Feature</th>
+            <th class="col-desc">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows.map((i) => html`
+            <tr class="sev-${i.severity}">
+              <td class="t">${this._formatTime(i.ts)}</td>
+              <td class="entity">${i.entity_id}</td>
+              <td class="sev"><span class="badge badge-${i.severity}">${i.severity}</span></td>
+              <td class="type">${i.type}</td>
+              <td class="key">${i.key || "—"}</td>
+              <td class="desc">${i.description}</td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .section {
+        background: var(--card-background-color);
+        border-radius: 8px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+      .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+      h2 { margin: 0; font-size: 1.1em; color: var(--primary-text-color); }
+      .summary { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
+      .chip {
+        padding: 2px 10px;
+        border-radius: 12px;
+        font-size: 0.8em;
+        font-weight: 600;
+      }
+      .chip-error { background: rgba(244, 67, 54, 0.15); color: var(--error-color, #f44336); }
+      .chip-warning { background: rgba(255, 152, 0, 0.15); color: var(--warning-color, #ff9800); }
+      .chip-info { background: rgba(3, 169, 244, 0.15); color: var(--primary-color, #03a9f4); }
+      .hint { color: var(--secondary-text-color); font-size: 0.85em; margin-left: 8px; }
+      .btn-danger {
+        background: var(--error-color, #f44336);
+        color: white;
+        border: none;
+        border-radius: 4px;
+        padding: 6px 12px;
+        cursor: pointer;
+      }
+      .btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
+      .error-text { color: var(--error-color, #f44336); margin-bottom: 8px; font-size: 0.9em; }
+      .empty { color: var(--secondary-text-color); font-style: italic; padding: 16px; text-align: center; }
+      .tabs { display: flex; gap: 0; border-bottom: 1px solid var(--divider-color); margin-bottom: 10px; }
+      .tab {
+        background: none;
+        border: none;
+        border-bottom: 2px solid transparent;
+        padding: 6px 14px;
+        color: var(--secondary-text-color);
+        font-size: 0.9em;
+        cursor: pointer;
+      }
+      .tab.active { color: var(--primary-text-color); border-bottom-color: var(--primary-color, #03a9f4); }
+      .issue-table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+      .issue-table th {
+        text-align: left;
+        padding: 6px 8px;
+        border-bottom: 1px solid var(--divider-color);
+        color: var(--secondary-text-color);
+        font-weight: 500;
+      }
+      .issue-table td { padding: 4px 8px; vertical-align: top; }
+      .t { font-family: monospace; color: var(--secondary-text-color); width: 80px; }
+      .entity { font-family: monospace; font-weight: 500; color: var(--primary-text-color); }
+      .type { font-family: monospace; color: var(--secondary-text-color); }
+      .key { font-family: monospace; color: var(--primary-text-color); }
+      .desc { color: var(--primary-text-color); }
+      .clean .entity, .clean td { color: var(--secondary-text-color); }
+      .badge {
+        display: inline-block;
+        padding: 1px 8px;
+        border-radius: 10px;
+        font-size: 0.7em;
+        font-weight: 600;
+        text-transform: uppercase;
+      }
+      .badge-error { background: rgba(244, 67, 54, 0.15); color: var(--error-color, #f44336); }
+      .badge-warning { background: rgba(255, 152, 0, 0.15); color: var(--warning-color, #ff9800); }
+      .badge-info { background: rgba(3, 169, 244, 0.15); color: var(--primary-color, #03a9f4); }
+      .badge-clean { background: rgba(76, 175, 80, 0.15); color: var(--success-color, #4caf50); }
+      .sev-error .desc { color: var(--error-color, #f44336); }
+      .sev-warning .desc { color: var(--warning-color, #ff9800); }
+    `;
+  }
+}
+
+customElements.define("sber-validation", SberValidation);

--- a/custom_components/sber_mqtt_bridge/www/sber-panel.js
+++ b/custom_components/sber_mqtt_bridge/www/sber-panel.js
@@ -23,6 +23,7 @@ await Promise.all([
   import(`./components/sber-traces.js${_q}`),
   import(`./components/sber-state-diff.js${_q}`),
   import(`./components/sber-replay.js${_q}`),
+  import(`./components/sber-validation.js${_q}`),
   import(`./components/sber-settings.js${_q}`),
   import(`./components/sber-link-dialog.js${_q}`),
 ]);
@@ -541,6 +542,7 @@ class SberMqttPanel extends LitElement {
       <sber-traces .hass=${this.hass}></sber-traces>
       <sber-state-diff .hass=${this.hass}></sber-state-diff>
       <sber-replay .hass=${this.hass}></sber-replay>
+      <sber-validation .hass=${this.hass}></sber-validation>
     `;
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sber-mqtt-bridge"
-version = "1.34.0"
+version = "1.35.0"
 description = "Sber Smart Home MQTT Bridge for Home Assistant"
 requires-python = ">=3.13"
 license = "MIT"

--- a/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
+++ b/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.34.0',
+        'hw_version': '1.35.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.34.0',
+        'sw_version': '1.35.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.34.0',
+        'hw_version': '1.35.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.34.0',
+        'sw_version': '1.35.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/snapshots/test_protocol_snapshots.ambr
+++ b/tests/hacs/snapshots/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.34.0',
+        'hw_version': '1.35.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.34.0',
+        'sw_version': '1.35.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.34.0',
+        'hw_version': '1.35.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.34.0',
+        'sw_version': '1.35.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/test_schema_validation_integration.py
+++ b/tests/hacs/test_schema_validation_integration.py
@@ -1,0 +1,91 @@
+"""End-to-end: a publish through the bridge records validation issues.
+
+Protects the one integration promise: every outbound state publish
+feeds the bridge's validation collector with a complete per-entity
+issue list.  A miss here means the DevTools panel lies about whether
+Sber will accept the payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.sber_mqtt_bridge.const import (
+    CONF_SBER_BROKER,
+    CONF_SBER_LOGIN,
+    CONF_SBER_PASSWORD,
+    CONF_SBER_PORT,
+)
+from custom_components.sber_mqtt_bridge.devices.relay import RelayEntity
+from custom_components.sber_mqtt_bridge.sber_bridge import SberBridge
+
+
+def _entry():
+    entry = MagicMock()
+    entry.data = {
+        CONF_SBER_LOGIN: "test",
+        CONF_SBER_PASSWORD: "pass",
+        CONF_SBER_BROKER: "broker.test",
+        CONF_SBER_PORT: 8883,
+    }
+    entry.options = {}
+    return entry
+
+
+def _hass():
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.config.location_name = "My Home"
+    tasks: list[asyncio.Task] = []
+
+    def capture(coro, **_):
+        t = asyncio.ensure_future(coro)
+        tasks.append(t)
+        return t
+
+    hass.async_create_task = MagicMock(side_effect=capture)
+    hass._created_tasks = tasks
+    return hass
+
+
+def _bridge_with_relay(hass):
+    bridge = SberBridge(hass, _entry())
+    bridge._mqtt_client = AsyncMock()
+    bridge._mqtt_service.publish = AsyncMock()
+    bridge._connected = True
+    bridge._ack_audit.cancel()
+    ent = RelayEntity({"entity_id": "switch.lamp", "name": "Lamp"})
+    ent.fill_by_ha_state({"entity_id": "switch.lamp", "state": "off", "attributes": {}})
+    bridge._entities["switch.lamp"] = ent
+    bridge._enabled_entity_ids = ["switch.lamp"]
+    return bridge
+
+
+async def _drain(hass):
+    for t in list(getattr(hass, "_created_tasks", [])):
+        if not t.done():
+            with contextlib.suppress(TimeoutError, Exception):
+                await asyncio.wait_for(t, timeout=5)
+
+
+class TestValidationIntegration:
+    async def test_publish_records_per_entity_view(self) -> None:
+        hass = _hass()
+        bridge = _bridge_with_relay(hass)
+        await bridge._publish_states(["switch.lamp"], force=True)
+        await _drain(hass)
+
+        snap = bridge.validation_collector.snapshot()
+        # The per-entity bucket must contain our entity — otherwise
+        # the UI has no data to render for a "current health" view.
+        assert "switch.lamp" in snap["by_entity"]
+
+    async def test_validation_collector_exposed_on_bridge(self) -> None:
+        # WS handlers reach the collector through this single attribute.
+        bridge = _bridge_with_relay(_hass())
+        assert bridge.validation_collector is not None
+        initial = bridge.validation_collector.snapshot()
+        assert initial == {"recent": [], "by_entity": {}}

--- a/tests/hacs/test_schema_validator.py
+++ b/tests/hacs/test_schema_validator.py
@@ -1,0 +1,293 @@
+"""Unit tests for the Sber schema validator.
+
+The validator is the canonical source of truth for "will Sber accept
+this publish?" — a false negative (issue not flagged) costs a user
+hours tracking down a silent rejection; a false positive drowns the
+DevTools panel in noise and trains users to ignore it.  Tests pin
+each check individually and the three collector views
+(``record`` / ``snapshot`` / ``subscribe``).
+"""
+
+from __future__ import annotations
+
+import json
+
+from custom_components.sber_mqtt_bridge.schema_validator import (
+    ValidationCollector,
+    ValidationIssue,
+    validate_publish,
+)
+
+
+def _state(key: str, type_: str, **body) -> dict:
+    return {"key": key, "value": {"type": type_, **body}}
+
+
+class TestMissingObligatory:
+    def test_all_obligatory_present_no_issue_of_that_type(self) -> None:
+        issues = validate_publish(
+            entity_id="light.x",
+            category="hub",
+            states=[_state("online", "BOOL", bool_value=True)],
+        )
+        assert not any(i.type == "missing_obligatory" for i in issues)
+
+    def test_missing_obligatory_is_error(self) -> None:
+        # hvac_ac requires hvac_temp_set + on_off + online per the spec.
+        issues = validate_publish(
+            entity_id="climate.a",
+            category="hvac_ac",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+        )
+        missing = {i.key for i in issues if i.type == "missing_obligatory"}
+        # Missing any of these is a hard rejection by Sber — must be error severity.
+        assert {"hvac_temp_set", "online"}.issubset(missing)
+        assert all(i.severity == "error" for i in issues if i.type == "missing_obligatory")
+
+    def test_unknown_category_skips_obligatory_check(self) -> None:
+        # Can't validate what we don't know — unknown category is a
+        # frequent case during codegen drift and must not spam issues.
+        issues = validate_publish(
+            entity_id="x.y",
+            category="future_category",
+            states=[_state("online", "BOOL", bool_value=True)],
+        )
+        assert not any(i.type == "missing_obligatory" for i in issues)
+
+
+class TestTypeMismatch:
+    def test_wrong_value_type_flagged_as_error(self) -> None:
+        # hvac_work_mode is ENUM; sending STRING is the textbook silent
+        # rejection path — the validator must flag it.
+        issues = validate_publish(
+            entity_id="climate.a",
+            category="hvac_ac",
+            states=[_state("hvac_work_mode", "STRING", string_value="cooling")],
+        )
+        mismatches = [i for i in issues if i.type == "type_mismatch"]
+        assert mismatches
+        assert mismatches[0].severity == "error"
+        assert mismatches[0].details == {"expected": "ENUM", "actual": "STRING"}
+
+    def test_correct_type_no_mismatch(self) -> None:
+        issues = validate_publish(
+            entity_id="light.x",
+            category="light",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+        )
+        assert not any(i.type == "type_mismatch" for i in issues)
+
+    def test_unknown_feature_key_is_not_a_type_mismatch(self) -> None:
+        # Unknown keys go through the "unknown_for_category" channel,
+        # not as type mismatches — otherwise a typo produces two issues
+        # per payload instead of one actionable one.
+        issues = validate_publish(
+            entity_id="light.x",
+            category="light",
+            states=[_state("ghost_feature", "INTEGER", integer_value=1)],
+        )
+        assert not any(i.type == "type_mismatch" for i in issues)
+
+
+class TestUnknownForCategory:
+    def test_feature_outside_reference_set_is_warning(self) -> None:
+        # hub has a small reference set — "on_off" is not in it.
+        issues = validate_publish(
+            entity_id="hub.x",
+            category="hub",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+        )
+        unknowns = [i for i in issues if i.type == "unknown_for_category"]
+        assert unknowns
+        assert unknowns[0].severity == "warning"
+
+    def test_known_feature_no_warning(self) -> None:
+        issues = validate_publish(
+            entity_id="light.x",
+            category="light",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+        )
+        assert not any(i.type == "unknown_for_category" for i in issues)
+
+
+class TestNotDeclared:
+    def test_state_key_outside_declared_is_info(self) -> None:
+        # User's device advertises only "online" but tries to publish
+        # "on_off" — Sber will ignore the latter.
+        issues = validate_publish(
+            entity_id="light.x",
+            category="light",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+            declared_features=["online"],
+        )
+        nots = [i for i in issues if i.type == "not_declared"]
+        assert nots
+        # Info, not error — the publish may still land (e.g. during
+        # feature rollout races) but the user should know.
+        assert nots[0].severity == "info"
+
+    def test_declared_keys_no_warning(self) -> None:
+        issues = validate_publish(
+            entity_id="light.x",
+            category="light",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+            declared_features=["on_off", "online"],
+        )
+        assert not any(i.type == "not_declared" for i in issues)
+
+    def test_declared_features_none_skips_check(self) -> None:
+        # Replay / synthetic payload may not have declared features —
+        # the check simply doesn't run instead of raising.
+        issues = validate_publish(
+            entity_id="light.x",
+            category="light",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+            declared_features=None,
+        )
+        assert not any(i.type == "not_declared" for i in issues)
+
+
+class TestCollector:
+    def test_record_replaces_per_entity_view(self) -> None:
+        vc = ValidationCollector()
+        # First publish — 1 issue; second publish — 0 issues.  UI must
+        # observe the entity going clean via the per-entity view.
+        issues = validate_publish(
+            entity_id="climate.a",
+            category="hvac_ac",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+        )
+        vc.record("climate.a", issues)
+        vc.record("climate.a", [])
+        snap = vc.snapshot()
+        assert snap["by_entity"]["climate.a"] == []
+
+    def test_recent_accumulates_across_publishes(self) -> None:
+        # Even after the entity snapshot goes clean, the chronological
+        # record must keep the historical issue so users can scroll back.
+        vc = ValidationCollector()
+        issues = validate_publish(
+            entity_id="climate.a",
+            category="hvac_ac",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+        )
+        vc.record("climate.a", issues)
+        vc.record("climate.a", [])
+        assert len(vc.snapshot()["recent"]) == len(issues)
+
+    def test_subscribers_called_only_for_non_empty_batches(self) -> None:
+        vc = ValidationCollector()
+        received: list[list[ValidationIssue]] = []
+        vc.subscribe(received.append)
+        vc.record("light.x", [])
+        assert received == []
+        issue = ValidationIssue(
+            ts=0,
+            entity_id="light.x",
+            category="light",
+            type="unknown_for_category",
+            severity="warning",
+            key="xxx",
+            description="test",
+            details={},
+        )
+        vc.record("light.x", [issue])
+        assert len(received) == 1
+
+    def test_subscriber_exception_does_not_break_collector(self) -> None:
+        vc = ValidationCollector()
+
+        def bad(_i):
+            raise RuntimeError("boom")
+
+        vc.subscribe(bad)
+        issue = ValidationIssue(
+            ts=0,
+            entity_id="x",
+            category="",
+            type="unknown_for_category",
+            severity="warning",
+            key="k",
+            description="t",
+            details={},
+        )
+        # Must not raise — bad subscriber must not take the bridge down.
+        vc.record("x", [issue])
+
+    def test_clear_drops_both_views(self) -> None:
+        vc = ValidationCollector()
+        issue = ValidationIssue(
+            ts=0,
+            entity_id="x",
+            category="",
+            type="unknown_for_category",
+            severity="warning",
+            key="k",
+            description="t",
+            details={},
+        )
+        vc.record("x", [issue])
+        vc.clear()
+        snap = vc.snapshot()
+        assert snap == {"recent": [], "by_entity": {}}
+
+
+class TestRecordPublishPayload:
+    def test_parses_and_records_per_device(self) -> None:
+        vc = ValidationCollector()
+        payload = json.dumps(
+            {
+                "devices": {
+                    "climate.a": {
+                        "states": [_state("on_off", "BOOL", bool_value=True)],
+                    },
+                    "light.x": {
+                        "states": [
+                            _state("on_off", "BOOL", bool_value=True),
+                            _state("online", "BOOL", bool_value=True),
+                        ],
+                    },
+                }
+            }
+        )
+        result = vc.record_publish_payload(
+            payload,
+            categories={"climate.a": "hvac_ac", "light.x": "light"},
+        )
+        # climate.a has missing obligatory fields; light.x is fine.
+        assert result["climate.a"]
+        assert result["light.x"] == []
+
+    def test_missing_category_map_still_runs_with_unknown(self) -> None:
+        vc = ValidationCollector()
+        # No category map at all — we still want SOME validation
+        # (type_mismatch) rather than bail out entirely.
+        payload = {
+            "devices": {
+                "x": {"states": [_state("on_off", "INTEGER", integer_value=1)]},
+            }
+        }
+        result = vc.record_publish_payload(payload)
+        # on_off is BOOL in the spec regardless of category → type_mismatch fires.
+        assert any(i.type == "type_mismatch" for i in result["x"])
+
+    def test_invalid_payload_returns_empty_dict(self) -> None:
+        vc = ValidationCollector()
+        assert vc.record_publish_payload("not json") == {}
+        assert vc.record_publish_payload({"devices": "nope"}) == {}  # type: ignore[arg-type]
+
+
+class TestSerialization:
+    def test_snapshot_is_json_serializable(self) -> None:
+        vc = ValidationCollector()
+        issues = validate_publish(
+            entity_id="climate.a",
+            category="hvac_ac",
+            states=[_state("on_off", "BOOL", bool_value=True)],
+        )
+        vc.record("climate.a", issues)
+        data = json.dumps(vc.snapshot())
+        # Fields read directly by the UI — renames silently break it.
+        assert '"severity"' in data
+        assert '"type"' in data
+        assert '"description"' in data

--- a/tests/hacs/test_websocket_validation.py
+++ b/tests/hacs/test_websocket_validation.py
@@ -1,0 +1,116 @@
+"""Tests for the schema-validation WebSocket commands.
+
+Guards the shape of WS payloads the DevTools panel reads directly
+(``recent`` / ``by_entity`` / ``issues`` / ``snapshot``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.sber_mqtt_bridge.schema_validator import (
+    ValidationCollector,
+    ValidationIssue,
+)
+from custom_components.sber_mqtt_bridge.websocket_api.validation import (
+    ws_clear_validation_issues,
+    ws_list_validation_issues,
+    ws_subscribe_validation_issues,
+)
+
+
+def _seeded_bridge() -> MagicMock:
+    bridge = MagicMock()
+    bridge.validation_collector = ValidationCollector()
+    issue = ValidationIssue(
+        ts=0,
+        entity_id="light.x",
+        category="light",
+        type="missing_obligatory",
+        severity="error",
+        key="online",
+        description="online required",
+        details={"missing": "online"},
+    )
+    bridge.validation_collector.record("light.x", [issue])
+    return bridge
+
+
+@pytest.fixture
+def connection():
+    conn = MagicMock()
+    conn.send_result = MagicMock()
+    conn.send_error = MagicMock()
+    conn.send_message = MagicMock()
+    conn.subscriptions = {}
+    return conn
+
+
+@pytest.fixture
+def hass():
+    return MagicMock()
+
+
+class TestListValidationIssues:
+    def test_returns_recent_and_by_entity(self, hass, connection):
+        bridge = _seeded_bridge()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.validation.get_bridge",
+            return_value=bridge,
+        ):
+            ws_list_validation_issues(hass, connection, {"id": 1})
+        payload = connection.send_result.call_args[0][1]
+        # Both views returned in one round-trip — splitting would force
+        # the UI to correlate them on its own.
+        assert "recent" in payload
+        assert "by_entity" in payload
+        assert payload["by_entity"]["light.x"][0]["severity"] == "error"
+
+    def test_missing_bridge_sends_error(self, hass, connection):
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.validation.get_bridge",
+            return_value=None,
+        ):
+            ws_list_validation_issues(hass, connection, {"id": 1})
+        connection.send_error.assert_called_once()
+
+
+class TestClearValidationIssues:
+    def test_clear_empties_collector(self, hass, connection):
+        bridge = _seeded_bridge()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.validation.get_bridge",
+            return_value=bridge,
+        ):
+            ws_clear_validation_issues(hass, connection, {"id": 2})
+        snap = bridge.validation_collector.snapshot()
+        assert snap == {"recent": [], "by_entity": {}}
+
+
+class TestSubscribeValidationIssues:
+    def test_subscribe_sends_snapshot_then_live(self, hass, connection):
+        bridge = _seeded_bridge()
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.validation.get_bridge",
+            return_value=bridge,
+        ):
+            ws_subscribe_validation_issues(hass, connection, {"id": 3})
+            # Emit a fresh batch — subscriber must see it as {"issues": [...]}.
+            issue = ValidationIssue(
+                ts=0,
+                entity_id="light.y",
+                category="light",
+                type="type_mismatch",
+                severity="error",
+                key="on_off",
+                description="wrong type",
+                details={"expected": "BOOL", "actual": "INTEGER"},
+            )
+            bridge.validation_collector.record("light.y", [issue])
+
+        # One snapshot + one live batch.
+        assert connection.send_message.call_count >= 2
+        # Subscription tracked for HA auto-unsub.
+        assert 3 in connection.subscriptions


### PR DESCRIPTION
## Summary

Fourth of five DevTools features.  Every outgoing Sber state publish
is checked against the **auto-generated Sber spec** in ``_generated/``
and findings surface as actionable issues in the panel — turning Sber
silent rejections into explicit guidance before the user even looks
at the cloud logs.

Four check classes:

| Type                  | Severity | Cause                                                 |
|-----------------------|----------|-------------------------------------------------------|
| `missing_obligatory`  | error    | Required feature for category absent — Sber drops it. |
| `type_mismatch`       | error    | `value.type` ≠ `FEATURE_TYPES[key]` — silent reject. |
| `unknown_for_category`| warning  | Feature outside category reference set.               |
| `not_declared`        | info     | State key not in the device's published features list.|

## Architecture

- **`schema_validator.py`** — pure-Python `validate_publish()` plus
  `ValidationCollector` with two views:
  - `recent` — chronological ring buffer.
  - `by_entity` — latest batch per entity, so the UI can render a
    "current health" table where entities flip clean as soon as the
    next publish has no issues.
- **Integration:** `SberBridge._publish_states` runs the validator
  over the serialized payload, using `entity.category` and
  `entity.get_final_features_list()` as context. Wrapped so a
  DevTools failure can never break publish.
- **WebSocket API (3 commands):** `validation_issues`,
  `clear_validation_issues`, `subscribe_validation_issues`.
- **UI** (`sber-validation.js`): DevTools tab with severity counters
  (errors / warnings / info) and two sub-tabs:
  - *By entity* — current status per entity, clean entities explicitly
    marked so fixes are visible.
  - *Timeline* — chronological feed.

## Why this matters

The Sber cloud silently drops devices that omit an obligatory feature
or send the wrong value type.  Today users discover this only after
the device fails to appear in Салют.  This view catches it at publish
time and says exactly which feature is wrong, so the fix takes seconds
instead of a debugging session.

## Test plan

- [x] `pytest tests/hacs/` → 1863 passed (26 new: 20 unit, 2 integration, 4 WS)
- [x] `ruff check` + `ruff format` clean
- [x] Snapshots bumped to v1.35.0 (both locations)
- [ ] Manual: add a device whose payload deliberately omits an
      obligatory feature, confirm it lights up red in the "By entity"
      tab with the missing feature name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)