### PR TITLE
feat: DevTools entity diagnose (v1.36.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.36.0] - 2026-04-22
+
+### Added
+
+- **DevTools: «Why isn't it working?» per-entity diagnose** —
+  один запрос собирает всю картину по конкретной entity из всех
+  уже подключённых источников (entity registry, ack-stats,
+  correlation trace, state diff, schema validation) и выдаёт
+  вердикт `ok` / `warning` / `broken` с конкретными findings и
+  actionable recommendations. Восемь правил:
+  - `not_known_to_bridge` (error) — entity не загружена.
+  - `not_enabled` (error) — загружена, но не включена.
+  - `linked_sensor` (info) — это linked sensor, диагностируй
+    primary.
+  - `not_filled_by_state` (warning) — HA ещё не прислал state.
+  - `never_acknowledged` (error) — Sber не подтвердил device
+    (silent rejection).
+  - `validation_errors` / `validation_warnings` (error/warning)
+    — найдены schema-validation issues.
+  - `recent_trace_failed` (error) — последняя trace ended as
+    failed.
+  - `recent_trace_timeout` (warning) — trace закрыт по timeout.
+
+  Verdict берёт худшую severity из findings. Новые компоненты:
+  - `diagnostics_advisor.py` — pure-функция
+    `diagnose_entity(bridge, entity_id) -> DiagnosticReport`;
+    каждое правило — независимая функция, легко добавлять новые.
+  - WebSocket API: `sber_mqtt_bridge/diagnose_entity`
+    (request/response, не subscribe).
+  - UI-компонент `sber-diagnose.js` во вкладке DevTools —
+    `entity_id` input + кнопка Diagnose, цветной verdict, список
+    findings с action-подсказкой, collapsible raw summary и
+    кнопка Copy report (для багрепортов).
+
 ## [1.35.0] - 2026-04-22
 
 ### Added

--- a/custom_components/sber_mqtt_bridge/diagnostics_advisor.py
+++ b/custom_components/sber_mqtt_bridge/diagnostics_advisor.py
@@ -1,0 +1,302 @@
+"""Per-entity "why isn't it working?" diagnostic advisor.
+
+Gathers every signal the bridge already exposes about one entity —
+whether it's loaded, linked, enabled, acknowledged, validated, plus
+the latest trace and state-diff records — and runs a cheap rule-based
+check that turns the raw data into an actionable verdict for the
+DevTools panel.
+
+Design:
+    * Pure function of ``bridge`` state — no timers, no side effects.
+    * Every rule returns a :class:`Finding` with ``severity`` so the
+      UI can colour-code; the report ``verdict`` is the worst severity
+      present (``broken`` > ``warning`` > ``ok``).
+    * The rules are deliberately independent one-liners: adding a
+      new heuristic is one function, no orchestrator changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from .sber_bridge import SberBridge
+
+Severity = Literal["error", "warning", "info", "ok"]
+Verdict = Literal["ok", "warning", "broken"]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One observation produced by a diagnostic rule."""
+
+    code: str
+    severity: Severity
+    title: str
+    detail: str
+    action: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass
+class DiagnosticReport:
+    """Aggregated per-entity diagnostic."""
+
+    entity_id: str
+    verdict: Verdict
+    findings: list[Finding] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return {
+            "entity_id": self.entity_id,
+            "verdict": self.verdict,
+            "findings": [f.as_dict() for f in self.findings],
+            "summary": self.summary,
+        }
+
+
+def _verdict_for(severities: list[Severity]) -> Verdict:
+    """Reduce a list of severities into a single trace-level verdict."""
+    if "error" in severities:
+        return "broken"
+    if "warning" in severities:
+        return "warning"
+    return "ok"
+
+
+def _collect_summary(bridge: SberBridge, entity_id: str) -> dict[str, Any]:
+    """Gather raw state about the entity for the UI to render as-is."""
+    entity = bridge._entities.get(entity_id)
+    enabled = entity_id in bridge._enabled_entity_ids
+    linked_role = bridge._linked_reverse.get(entity_id)
+    acknowledged = entity_id in bridge._stats.acknowledged_entities
+
+    # Latest trace that touched this entity (may be active or closed).
+    last_trace = None
+    for t in reversed(bridge.trace_collector.snapshot()):
+        if entity_id in (t.get("entity_ids") or []):
+            last_trace = t
+            break
+
+    # Latest state diff and validation issues.
+    last_diff = None
+    for d in reversed(bridge.diff_collector.snapshot()):
+        if d.get("entity_id") == entity_id:
+            last_diff = d
+            break
+
+    validation_by_entity = bridge.validation_collector.snapshot().get("by_entity", {})
+    current_issues = validation_by_entity.get(entity_id, [])
+
+    return {
+        "known_to_bridge": entity is not None,
+        "category": getattr(entity, "category", None),
+        "enabled": enabled,
+        "linked_role": ({"primary_entity_id": linked_role[0], "role": linked_role[1]} if linked_role else None),
+        "acknowledged_by_sber": acknowledged,
+        "is_filled_by_state": getattr(entity, "is_filled_by_state", None),
+        "declared_features": (entity.get_final_features_list() if entity is not None else None),
+        "last_trace": last_trace,
+        "last_diff": last_diff,
+        "current_validation_issues": current_issues,
+    }
+
+
+def _rule_not_known(summary: dict[str, Any]) -> Finding | None:
+    if summary["known_to_bridge"]:
+        return None
+    return Finding(
+        code="not_known_to_bridge",
+        severity="error",
+        title="Bridge does not know this entity",
+        detail=(
+            "The entity_id is not loaded in the bridge.  It was either "
+            "never added, was removed, or the integration didn't reload "
+            "after a config change."
+        ),
+        action=("Open the devices wizard and add the entity, or reload the Sber MQTT Bridge integration."),
+    )
+
+
+def _rule_not_enabled(summary: dict[str, Any]) -> Finding | None:
+    if not summary["known_to_bridge"]:
+        return None  # Covered by _rule_not_known.
+    if summary["enabled"]:
+        return None
+    return Finding(
+        code="not_enabled",
+        severity="error",
+        title="Entity is known but not enabled",
+        detail="Bridge sees the entity but will not publish it to Sber.",
+        action="Enable it in the devices wizard.",
+    )
+
+
+def _rule_linked(summary: dict[str, Any]) -> Finding | None:
+    role = summary["linked_role"]
+    if not role:
+        return None
+    return Finding(
+        code="linked_sensor",
+        severity="info",
+        title="This is a linked sensor",
+        detail=(
+            f"State changes are forwarded to primary device "
+            f"'{role['primary_entity_id']}' under role '{role['role']}'. "
+            "Diagnose the primary if the user-facing behaviour is broken."
+        ),
+        action=f"Run diagnose on {role['primary_entity_id']} instead.",
+    )
+
+
+def _rule_not_filled(summary: dict[str, Any]) -> Finding | None:
+    if not summary["known_to_bridge"]:
+        return None
+    if summary["is_filled_by_state"] is False:
+        return Finding(
+            code="not_filled_by_state",
+            severity="warning",
+            title="HA state has not populated the entity yet",
+            detail=(
+                "The bridge has no state snapshot for this entity — "
+                "likely HA returned `unavailable` or the entity hasn't "
+                "emitted a state_changed event since startup."
+            ),
+            action=(
+                "Trigger the device once from HA so a state_changed "
+                "event fires, or check that the underlying integration "
+                "is healthy."
+            ),
+        )
+    return None
+
+
+def _rule_never_acknowledged(summary: dict[str, Any]) -> Finding | None:
+    if not summary["enabled"]:
+        return None
+    if summary["acknowledged_by_sber"]:
+        return None
+    return Finding(
+        code="never_acknowledged",
+        severity="error",
+        title="Sber has never acknowledged this device",
+        detail=(
+            "The bridge has published this entity's config at least "
+            "once, but Sber has not issued a status_request or command "
+            "for it.  Common causes: category mismatch (Sber silently "
+            "drops unknown categories), obligatory feature missing, "
+            "device not registered in Sber Studio."
+        ),
+        action=(
+            "Check the Schema Validation tab for this entity; if clean, "
+            "confirm the device exists in Sber Studio and republish."
+        ),
+    )
+
+
+def _rule_validation_errors(summary: dict[str, Any]) -> Finding | None:
+    errors = [i for i in summary["current_validation_issues"] if i.get("severity") == "error"]
+    if not errors:
+        return None
+    keys = ", ".join(sorted({i.get("key") or "?" for i in errors}))
+    return Finding(
+        code="validation_errors",
+        severity="error",
+        title=f"{len(errors)} schema validation error(s)",
+        detail=(f"The latest publish failed validation on: {keys}.  Sber is likely silently rejecting the payload."),
+        action="Open the Schema Validation tab for the full list.",
+    )
+
+
+def _rule_validation_warnings(summary: dict[str, Any]) -> Finding | None:
+    warnings = [i for i in summary["current_validation_issues"] if i.get("severity") == "warning"]
+    if not warnings:
+        return None
+    return Finding(
+        code="validation_warnings",
+        severity="warning",
+        title=f"{len(warnings)} schema validation warning(s)",
+        detail=("Payload may still work today but is drifting from the Sber spec — easy future breakage."),
+        action="Review in the Schema Validation tab.",
+    )
+
+
+def _rule_recent_trace(summary: dict[str, Any]) -> Finding | None:
+    t = summary["last_trace"]
+    if not t:
+        return None
+    status = t.get("status")
+    if status == "failed":
+        return Finding(
+            code="recent_trace_failed",
+            severity="error",
+            title="Last command trace ended in failure",
+            detail=(
+                "The most recent Sber command involving this entity "
+                "did not receive an acknowledgment (silent rejection)."
+            ),
+            action="Check the Correlation Timeline for the failed trace.",
+        )
+    if status == "timeout":
+        return Finding(
+            code="recent_trace_timeout",
+            severity="warning",
+            title="Last trace timed out without a publish",
+            detail=(
+                "The bridge saw a Sber command but never emitted a "
+                "corresponding publish within the trace window — "
+                "possibly a HA service call that did nothing."
+            ),
+            action="Check the Correlation Timeline + HA logs for service errors.",
+        )
+    return None
+
+
+_RULES = (
+    _rule_not_known,
+    _rule_not_enabled,
+    _rule_linked,
+    _rule_not_filled,
+    _rule_never_acknowledged,
+    _rule_validation_errors,
+    _rule_validation_warnings,
+    _rule_recent_trace,
+)
+
+
+def diagnose_entity(bridge: SberBridge, entity_id: str) -> DiagnosticReport:
+    """Run every diagnostic rule against ``entity_id`` and produce a report."""
+    summary = _collect_summary(bridge, entity_id)
+    findings: list[Finding] = []
+    for rule in _RULES:
+        f = rule(summary)
+        if f is not None:
+            findings.append(f)
+
+    verdict = _verdict_for([f.severity for f in findings])
+    if verdict == "ok" and not findings:
+        # Signal the "all clear" state explicitly so the UI shows the
+        # green verdict rather than an empty list that looks unfinished.
+        findings.append(
+            Finding(
+                code="clean",
+                severity="ok",
+                title="No issues detected",
+                detail=(
+                    "The entity is loaded, enabled, acknowledged by Sber, "
+                    "and the latest publish passes schema validation."
+                ),
+            )
+        )
+    return DiagnosticReport(
+        entity_id=entity_id,
+        verdict=verdict,
+        findings=findings,
+        summary=summary,
+    )

--- a/custom_components/sber_mqtt_bridge/manifest.json
+++ b/custom_components/sber_mqtt_bridge/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dzerik/sber-mqtt-bridge/issues",
   "loggers": ["aiomqtt"],
   "requirements": ["aiomqtt>=2.0,<3.0", "pydantic>=2.0,<3.0"],
-  "version": "1.35.0"
+  "version": "1.36.0"
 }

--- a/custom_components/sber_mqtt_bridge/sber_protocol.py
+++ b/custom_components/sber_mqtt_bridge/sber_protocol.py
@@ -15,7 +15,7 @@ from .sber_models import validate_config_payload, validate_device, validate_stat
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = "1.35.0"
+VERSION = "1.36.0"
 """Protocol version string included in the hub device descriptor."""
 
 

--- a/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/__init__.py
@@ -19,6 +19,7 @@ modules to keep per-file size and concerns focused:
 - ``diffs``           — state-payload diffs (DevTools #2)
 - ``replay``          — replay / inject Sber messages (DevTools #3)
 - ``validation``      — Sber schema validation issues (DevTools #4)
+- ``diagnose``        — per-entity diagnostic advisor (DevTools #5)
 
 All public ``ws_*`` command functions are re-exported at package level
 for test introspection.
@@ -38,6 +39,7 @@ from .devices_grouped import (
     ws_list_devices_for_category,
     ws_suggest_links,
 )
+from .diagnose import ws_diagnose_entity
 from .diffs import ws_clear_state_diffs, ws_list_state_diffs, ws_subscribe_state_diffs
 from .entities import (
     ws_add_entities,
@@ -80,6 +82,7 @@ __all__ = [
     "ws_clear_traces",
     "ws_clear_validation_issues",
     "ws_device_detail",
+    "ws_diagnose_entity",
     "ws_export",
     "ws_get_devices",
     "ws_get_settings",
@@ -163,6 +166,8 @@ _COMMANDS = (
     ws_list_validation_issues,
     ws_clear_validation_issues,
     ws_subscribe_validation_issues,
+    # DevTools entity diagnose (v1.36.0)
+    ws_diagnose_entity,
     # Settings
     ws_get_settings,
     ws_update_settings,

--- a/custom_components/sber_mqtt_bridge/websocket_api/diagnose.py
+++ b/custom_components/sber_mqtt_bridge/websocket_api/diagnose.py
@@ -1,0 +1,44 @@
+"""Diagnostic-advisor WebSocket command (DevTools #5).
+
+Single request/response command — ``diagnose_entity`` — that returns
+a full per-entity health report built from the signals the bridge
+already exposes (entity registry, ack stats, correlation trace,
+schema validation).  No subscribe channel: diagnostics are
+user-initiated ("Why isn't X working?") so there's no background
+stream to push.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+
+from ..diagnostics_advisor import diagnose_entity
+from ._common import get_bridge
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "sber_mqtt_bridge/diagnose_entity",
+        vol.Required("entity_id"): str,
+    }
+)
+@callback
+def ws_diagnose_entity(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return a full diagnostic report for ``entity_id``."""
+    bridge = get_bridge(hass)
+    if bridge is None:
+        connection.send_error(msg["id"], "bridge_not_found", "Bridge not available")
+        return
+    report = diagnose_entity(bridge, msg["entity_id"])
+    connection.send_result(msg["id"], {"report": report.as_dict()})

--- a/custom_components/sber_mqtt_bridge/www/components/sber-diagnose.js
+++ b/custom_components/sber_mqtt_bridge/www/components/sber-diagnose.js
@@ -1,0 +1,254 @@
+/**
+ * Sber MQTT Bridge — per-entity diagnostic advisor (DevTools #5).
+ *
+ * Compact form:
+ *   * entity_id input + "Diagnose" button,
+ *   * verdict badge (ok / warning / broken),
+ *   * list of findings with severity + title + detail + action,
+ *   * collapsible raw summary for power users who want everything.
+ *
+ * Designed to be pastable into a bug report — one click produces a
+ * self-contained readout of everything the bridge knows about one
+ * entity.
+ */
+
+const LitElement = Object.getPrototypeOf(
+  customElements.get("ha-panel-lovelace") ?? customElements.get("hui-view")
+);
+const html = LitElement?.prototype.html;
+const css = LitElement?.prototype.css;
+
+const VERDICT_LABEL = {
+  ok: "Clean",
+  warning: "Warnings",
+  broken: "Broken",
+};
+
+class SberDiagnose extends LitElement {
+  static get properties() {
+    return {
+      hass: { type: Object },
+      _entityId: { type: String },
+      _report: { type: Object },
+      _loading: { type: Boolean },
+      _error: { type: String },
+      _rawOpen: { type: Boolean },
+    };
+  }
+
+  constructor() {
+    super();
+    this._entityId = "";
+    this._report = null;
+    this._loading = false;
+    this._error = "";
+    this._rawOpen = false;
+  }
+
+  async _run() {
+    if (this._loading) return;
+    this._error = "";
+    if (!this._entityId.trim()) {
+      this._error = "Enter an entity_id to diagnose.";
+      return;
+    }
+    this._loading = true;
+    try {
+      const result = await this.hass.callWS({
+        type: "sber_mqtt_bridge/diagnose_entity",
+        entity_id: this._entityId.trim(),
+      });
+      this._report = result.report;
+    } catch (e) {
+      this._error = e.message || String(e);
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  async _copyReport() {
+    if (!this._report) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(this._report, null, 2));
+    } catch (e) {
+      this._error = `Copy failed: ${e.message || e}`;
+    }
+  }
+
+  render() {
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <h2>Why isn't it working?</h2>
+        </div>
+        <div class="hint">
+          Runs every diagnostic rule the bridge knows against one entity — loaded, linked, enabled, acknowledged, validated, recent traces — and returns a verdict with actionable next steps.
+        </div>
+        <div class="form-row">
+          <input
+            type="text"
+            placeholder="entity_id (e.g. light.kitchen)"
+            .value=${this._entityId}
+            @input=${(e) => { this._entityId = e.target.value; }}
+            @keydown=${(e) => { if (e.key === "Enter") this._run(); }}
+          />
+          <button class="btn-primary"
+            ?disabled=${this._loading}
+            @click=${this._run}>
+            ${this._loading ? "Running..." : "Diagnose"}
+          </button>
+          ${this._report ? html`
+            <button class="btn-secondary" @click=${this._copyReport}>Copy report</button>
+          ` : ""}
+        </div>
+        ${this._error ? html`<div class="error-text">${this._error}</div>` : ""}
+        ${this._report ? this._renderReport(this._report) : ""}
+      </div>
+    `;
+  }
+
+  _renderReport(r) {
+    const verdict = r.verdict;
+    return html`
+      <div class="verdict verdict-${verdict}">
+        <span class="verdict-badge verdict-badge-${verdict}">${VERDICT_LABEL[verdict] || verdict}</span>
+        <span class="verdict-entity">${r.entity_id}</span>
+      </div>
+      <div class="findings">
+        ${(r.findings || []).map((f) => html`
+          <div class="finding finding-${f.severity}">
+            <div class="finding-head">
+              <span class="sev-dot sev-${f.severity}"></span>
+              <span class="finding-title">${f.title}</span>
+              <span class="finding-code">${f.code}</span>
+            </div>
+            <div class="finding-detail">${f.detail}</div>
+            ${f.action ? html`<div class="finding-action"><strong>Action:</strong> ${f.action}</div>` : ""}
+          </div>
+        `)}
+      </div>
+      <div class="raw-toggle" @click=${() => { this._rawOpen = !this._rawOpen; }}>
+        <span class="caret ${this._rawOpen ? "open" : ""}">&#9654;</span>
+        Raw summary
+      </div>
+      ${this._rawOpen ? html`<pre class="raw">${JSON.stringify(r.summary, null, 2)}</pre>` : ""}
+    `;
+  }
+
+  static get styles() {
+    return css`
+      .section {
+        background: var(--card-background-color);
+        border-radius: 8px;
+        padding: 16px;
+        margin-bottom: 16px;
+      }
+      .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+      h2 { margin: 0; font-size: 1.1em; color: var(--primary-text-color); }
+      .hint { color: var(--secondary-text-color); font-size: 0.85em; margin-bottom: 12px; }
+      .form-row { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; }
+      input {
+        flex: 1;
+        padding: 6px 10px;
+        border: 1px solid var(--divider-color);
+        border-radius: 4px;
+        background: var(--primary-background-color);
+        color: var(--primary-text-color);
+        font-family: monospace;
+      }
+      .btn-primary {
+        background: var(--primary-color, #03a9f4);
+        color: white;
+        border: none;
+        border-radius: 4px;
+        padding: 6px 14px;
+        cursor: pointer;
+      }
+      .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+      .btn-secondary {
+        background: var(--secondary-background-color);
+        color: var(--primary-text-color);
+        border: 1px solid var(--divider-color);
+        border-radius: 4px;
+        padding: 6px 12px;
+        cursor: pointer;
+      }
+      .error-text { color: var(--error-color, #f44336); margin-bottom: 8px; font-size: 0.9em; }
+      .verdict {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px;
+        border-radius: 6px;
+        margin-bottom: 12px;
+      }
+      .verdict-ok { background: rgba(76, 175, 80, 0.08); }
+      .verdict-warning { background: rgba(255, 152, 0, 0.08); }
+      .verdict-broken { background: rgba(244, 67, 54, 0.08); }
+      .verdict-badge {
+        padding: 3px 12px;
+        border-radius: 14px;
+        font-size: 0.8em;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+      .verdict-badge-ok { background: rgba(76, 175, 80, 0.2); color: var(--success-color, #4caf50); }
+      .verdict-badge-warning { background: rgba(255, 152, 0, 0.2); color: var(--warning-color, #ff9800); }
+      .verdict-badge-broken { background: rgba(244, 67, 54, 0.2); color: var(--error-color, #f44336); }
+      .verdict-entity { font-family: monospace; color: var(--primary-text-color); }
+      .findings { display: flex; flex-direction: column; gap: 8px; }
+      .finding {
+        border: 1px solid var(--divider-color);
+        border-left-width: 3px;
+        border-radius: 4px;
+        padding: 10px 12px;
+        background: var(--primary-background-color);
+      }
+      .finding-error { border-left-color: var(--error-color, #f44336); }
+      .finding-warning { border-left-color: var(--warning-color, #ff9800); }
+      .finding-info { border-left-color: var(--primary-color, #03a9f4); }
+      .finding-ok { border-left-color: var(--success-color, #4caf50); }
+      .finding-head { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
+      .sev-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        display: inline-block;
+      }
+      .sev-error { background: var(--error-color, #f44336); }
+      .sev-warning { background: var(--warning-color, #ff9800); }
+      .sev-info { background: var(--primary-color, #03a9f4); }
+      .sev-ok { background: var(--success-color, #4caf50); }
+      .finding-title { font-weight: 600; color: var(--primary-text-color); flex: 1; }
+      .finding-code { font-family: monospace; font-size: 0.75em; color: var(--secondary-text-color); }
+      .finding-detail { color: var(--primary-text-color); font-size: 0.9em; line-height: 1.4; }
+      .finding-action {
+        margin-top: 6px;
+        padding: 4px 8px;
+        background: var(--secondary-background-color);
+        border-radius: 3px;
+        font-size: 0.85em;
+      }
+      .raw-toggle {
+        margin-top: 14px;
+        color: var(--secondary-text-color);
+        cursor: pointer;
+        font-size: 0.85em;
+        user-select: none;
+      }
+      .caret { display: inline-block; transition: transform 0.15s; margin-right: 4px; }
+      .caret.open { transform: rotate(90deg); }
+      .raw {
+        background: var(--secondary-background-color);
+        padding: 10px;
+        border-radius: 4px;
+        font-family: monospace;
+        font-size: 0.8em;
+        overflow: auto;
+        max-height: 300px;
+      }
+    `;
+  }
+}
+
+customElements.define("sber-diagnose", SberDiagnose);

--- a/custom_components/sber_mqtt_bridge/www/sber-panel.js
+++ b/custom_components/sber_mqtt_bridge/www/sber-panel.js
@@ -24,6 +24,7 @@ await Promise.all([
   import(`./components/sber-state-diff.js${_q}`),
   import(`./components/sber-replay.js${_q}`),
   import(`./components/sber-validation.js${_q}`),
+  import(`./components/sber-diagnose.js${_q}`),
   import(`./components/sber-settings.js${_q}`),
   import(`./components/sber-link-dialog.js${_q}`),
 ]);
@@ -543,6 +544,7 @@ class SberMqttPanel extends LitElement {
       <sber-state-diff .hass=${this.hass}></sber-state-diff>
       <sber-replay .hass=${this.hass}></sber-replay>
       <sber-validation .hass=${this.hass}></sber-validation>
+      <sber-diagnose .hass=${this.hass}></sber-diagnose>
     `;
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sber-mqtt-bridge"
-version = "1.35.0"
+version = "1.36.0"
 description = "Sber Smart Home MQTT Bridge for Home Assistant"
 requires-python = ">=3.13"
 license = "MIT"

--- a/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
+++ b/tests/hacs/__snapshots__/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.35.0',
+        'hw_version': '1.36.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.35.0',
+        'sw_version': '1.36.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.35.0',
+        'hw_version': '1.36.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.35.0',
+        'sw_version': '1.36.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/snapshots/test_protocol_snapshots.ambr
+++ b/tests/hacs/snapshots/test_protocol_snapshots.ambr
@@ -5,7 +5,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.35.0',
+        'hw_version': '1.36.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -19,7 +19,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.35.0',
+        'sw_version': '1.36.0',
       }),
       dict({
         'default_name': 'switch.lamp',
@@ -71,7 +71,7 @@
       dict({
         'default_name': 'HA-SberBridge Hub',
         'home': 'Мой дом',
-        'hw_version': '1.35.0',
+        'hw_version': '1.36.0',
         'id': 'root',
         'model': dict({
           'category': 'hub',
@@ -85,7 +85,7 @@
         }),
         'name': 'Home Assistant Bridge',
         'room': 'Мой дом',
-        'sw_version': '1.35.0',
+        'sw_version': '1.36.0',
       }),
       dict({
         'default_name': 'switch.lamp',

--- a/tests/hacs/test_diagnostics_advisor.py
+++ b/tests/hacs/test_diagnostics_advisor.py
@@ -1,0 +1,219 @@
+"""Unit tests for the per-entity diagnostic advisor.
+
+The advisor is a pure reducer over bridge state — breakage here
+silently lies to the user ("no issues detected" when the entity is
+dead, or "broken" for a healthy device).  These tests pin each rule
+individually and the verdict aggregation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.sber_mqtt_bridge.diagnostics_advisor import (
+    DiagnosticReport,
+    Finding,
+    diagnose_entity,
+)
+from custom_components.sber_mqtt_bridge.schema_validator import (
+    ValidationCollector,
+    ValidationIssue,
+)
+from custom_components.sber_mqtt_bridge.state_diff import DiffCollector
+from custom_components.sber_mqtt_bridge.trace_collector import TraceCollector
+
+
+def _bridge(
+    *,
+    known: bool = True,
+    enabled: bool = True,
+    acknowledged: bool = True,
+    filled: bool = True,
+    linked_role: tuple[str, str] | None = None,
+    category: str = "light",
+    features: list[str] | None = None,
+) -> MagicMock:
+    """Assemble a minimal MagicMock bridge exposing the fields the advisor reads."""
+    bridge = MagicMock()
+    bridge._entities = {}
+    if known:
+        entity = MagicMock()
+        entity.category = category
+        entity.is_filled_by_state = filled
+        entity.get_final_features_list = MagicMock(return_value=features or ["on_off", "online"])
+        bridge._entities["x.y"] = entity
+    bridge._enabled_entity_ids = ["x.y"] if enabled else []
+    bridge._linked_reverse = {"x.y": linked_role} if linked_role else {}
+    stats = MagicMock()
+    stats.acknowledged_entities = {"x.y"} if acknowledged else set()
+    bridge._stats = stats
+    bridge.trace_collector = TraceCollector()
+    bridge.diff_collector = DiffCollector()
+    bridge.validation_collector = ValidationCollector()
+    return bridge
+
+
+class TestBasicRules:
+    def test_clean_entity_returns_ok_verdict(self) -> None:
+        report = diagnose_entity(_bridge(), "x.y")
+        # Green path must surface an explicit "clean" finding —
+        # otherwise the UI shows an empty list that looks unfinished.
+        assert report.verdict == "ok"
+        assert any(f.code == "clean" for f in report.findings)
+
+    def test_unknown_entity_is_broken(self) -> None:
+        report = diagnose_entity(_bridge(known=False, enabled=False), "x.y")
+        assert report.verdict == "broken"
+        assert any(f.code == "not_known_to_bridge" for f in report.findings)
+
+    def test_known_but_not_enabled_is_broken(self) -> None:
+        report = diagnose_entity(_bridge(enabled=False), "x.y")
+        codes = {f.code for f in report.findings}
+        assert "not_enabled" in codes
+        assert report.verdict == "broken"
+
+    def test_never_acknowledged_is_error_with_actionable_hint(self) -> None:
+        # The most user-visible failure mode — Sber silent rejection.
+        report = diagnose_entity(_bridge(acknowledged=False), "x.y")
+        finding = next(f for f in report.findings if f.code == "never_acknowledged")
+        assert finding.severity == "error"
+        # The action must point the user to something concrete, not just
+        # "something is wrong".
+        assert finding.action
+
+
+class TestLinkedSensor:
+    def test_linked_sensor_gets_info_redirect(self) -> None:
+        # Users often diagnose the wrong thing (linked sensor) — the
+        # advisor must redirect them to the primary.
+        report = diagnose_entity(_bridge(linked_role=("light.primary", "brightness")), "x.y")
+        finding = next(f for f in report.findings if f.code == "linked_sensor")
+        assert finding.severity == "info"
+        assert "light.primary" in finding.action
+
+
+class TestFilledByState:
+    def test_not_filled_is_warning(self) -> None:
+        report = diagnose_entity(_bridge(filled=False), "x.y")
+        codes = {f.code for f in report.findings}
+        assert "not_filled_by_state" in codes
+        # Warning, not error — the bridge is healthy, the upstream
+        # integration is the problem.
+        assert report.verdict in {"warning", "broken"}
+
+
+class TestValidationRules:
+    def test_validation_error_surfaced(self) -> None:
+        bridge = _bridge()
+        bridge.validation_collector.record(
+            "x.y",
+            [
+                ValidationIssue(
+                    ts=0,
+                    entity_id="x.y",
+                    category="light",
+                    type="type_mismatch",
+                    severity="error",
+                    key="on_off",
+                    description="bad",
+                    details={},
+                )
+            ],
+        )
+        report = diagnose_entity(bridge, "x.y")
+        assert any(f.code == "validation_errors" for f in report.findings)
+        assert report.verdict == "broken"
+
+    def test_validation_warning_only_is_warning(self) -> None:
+        bridge = _bridge()
+        bridge.validation_collector.record(
+            "x.y",
+            [
+                ValidationIssue(
+                    ts=0,
+                    entity_id="x.y",
+                    category="light",
+                    type="unknown_for_category",
+                    severity="warning",
+                    key="on_off",
+                    description="unknown",
+                    details={},
+                )
+            ],
+        )
+        report = diagnose_entity(bridge, "x.y")
+        assert report.verdict == "warning"
+        assert any(f.code == "validation_warnings" for f in report.findings)
+
+
+class TestRecentTrace:
+    def test_failed_trace_is_error(self) -> None:
+        bridge = _bridge()
+        tr = bridge.trace_collector.begin(
+            trace_id="t1",
+            trigger="sber_command",
+            entity_ids=["x.y"],
+        )
+        tr.status = "failed"  # Simulate silent rejection via AckAudit.
+        report = diagnose_entity(bridge, "x.y")
+        assert any(f.code == "recent_trace_failed" for f in report.findings)
+
+    def test_timeout_trace_is_warning(self) -> None:
+        bridge = _bridge()
+        tr = bridge.trace_collector.begin(
+            trace_id="t1",
+            trigger="sber_command",
+            entity_ids=["x.y"],
+        )
+        tr.status = "timeout"
+        report = diagnose_entity(bridge, "x.y")
+        assert any(f.code == "recent_trace_timeout" for f in report.findings)
+
+    def test_success_trace_produces_no_finding(self) -> None:
+        bridge = _bridge()
+        tr = bridge.trace_collector.begin(
+            trace_id="t1",
+            trigger="sber_command",
+            entity_ids=["x.y"],
+        )
+        tr.status = "success"
+        report = diagnose_entity(bridge, "x.y")
+        # Successful traces must not produce noise.
+        assert not any(f.code.startswith("recent_trace") for f in report.findings)
+
+
+class TestVerdictAggregation:
+    def test_verdict_picks_worst_severity(self) -> None:
+        # Mix of info + error must still produce "broken", not
+        # average-out to "warning".
+        bridge = _bridge(acknowledged=False, linked_role=("a.b", "r"))
+        report = diagnose_entity(bridge, "x.y")
+        assert report.verdict == "broken"
+
+
+class TestSerialization:
+    def test_report_is_json_serializable(self) -> None:
+        import json
+
+        report = diagnose_entity(_bridge(), "x.y")
+        data = json.dumps(report.as_dict())
+        # Field names read directly by the UI — renames silently break it.
+        assert '"verdict"' in data
+        assert '"findings"' in data
+        assert '"summary"' in data
+
+    def test_finding_has_expected_fields(self) -> None:
+        f = Finding(code="x", severity="info", title="t", detail="d")
+        d = f.as_dict()
+        assert set(d.keys()) == {"code", "severity", "title", "detail", "action"}
+
+
+class TestReportDataclass:
+    def test_construct_empty_and_serialize(self) -> None:
+        r = DiagnosticReport(entity_id="x", verdict="ok")
+        assert r.as_dict() == {
+            "entity_id": "x",
+            "verdict": "ok",
+            "findings": [],
+            "summary": {},
+        }

--- a/tests/hacs/test_websocket_diagnose.py
+++ b/tests/hacs/test_websocket_diagnose.py
@@ -1,0 +1,87 @@
+"""Tests for the per-entity diagnose WebSocket command.
+
+Guards the single payload shape the DevTools panel reads
+(``{"report": {...}}``) and the error paths (missing bridge, unknown
+entity_id still produces a valid broken-verdict report instead of a
+send_error).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.sber_mqtt_bridge.schema_validator import ValidationCollector
+from custom_components.sber_mqtt_bridge.state_diff import DiffCollector
+from custom_components.sber_mqtt_bridge.trace_collector import TraceCollector
+from custom_components.sber_mqtt_bridge.websocket_api.diagnose import (
+    ws_diagnose_entity,
+)
+
+
+def _bridge_clean() -> MagicMock:
+    bridge = MagicMock()
+    entity = MagicMock()
+    entity.category = "light"
+    entity.is_filled_by_state = True
+    entity.get_final_features_list = MagicMock(return_value=["on_off", "online"])
+    bridge._entities = {"light.x": entity}
+    bridge._enabled_entity_ids = ["light.x"]
+    bridge._linked_reverse = {}
+    stats = MagicMock()
+    stats.acknowledged_entities = {"light.x"}
+    bridge._stats = stats
+    bridge.trace_collector = TraceCollector()
+    bridge.diff_collector = DiffCollector()
+    bridge.validation_collector = ValidationCollector()
+    return bridge
+
+
+@pytest.fixture
+def connection():
+    conn = MagicMock()
+    conn.send_result = MagicMock()
+    conn.send_error = MagicMock()
+    return conn
+
+
+@pytest.fixture
+def hass():
+    return MagicMock()
+
+
+class TestDiagnoseEntity:
+    def test_clean_entity_returns_ok_verdict(self, hass, connection):
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.diagnose.get_bridge",
+            return_value=_bridge_clean(),
+        ):
+            ws_diagnose_entity(hass, connection, {"id": 1, "entity_id": "light.x"})
+        payload = connection.send_result.call_args[0][1]
+        assert "report" in payload
+        # UI reads these three top-level fields.
+        assert set(payload["report"].keys()) >= {"entity_id", "verdict", "findings", "summary"}
+        assert payload["report"]["verdict"] == "ok"
+
+    def test_unknown_entity_returns_broken_verdict_not_error(self, hass, connection):
+        # Typing a non-existent entity_id is a legit diagnostic path —
+        # we must return the "not_known_to_bridge" finding, not a
+        # WebSocket error that hides the diagnosis from the user.
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.diagnose.get_bridge",
+            return_value=_bridge_clean(),
+        ):
+            ws_diagnose_entity(hass, connection, {"id": 2, "entity_id": "nope.nope"})
+        payload = connection.send_result.call_args[0][1]
+        assert payload["report"]["verdict"] == "broken"
+        connection.send_error.assert_not_called()
+
+    def test_missing_bridge_sends_error(self, hass, connection):
+        with patch(
+            "custom_components.sber_mqtt_bridge.websocket_api.diagnose.get_bridge",
+            return_value=None,
+        ):
+            ws_diagnose_entity(hass, connection, {"id": 3, "entity_id": "light.x"})
+        connection.send_error.assert_called_once()
+        assert connection.send_error.call_args[0][1] == "bridge_not_found"


### PR DESCRIPTION
## Summary

Fifth and final planned DevTools feature.  A per-entity "why isn't it
working?" advisor that one-shots every signal the bridge already
exposes about one entity — loaded, linked, enabled, acknowledged by
Sber, schema-validated, plus the latest trace and state diff — and
produces a verdict (`ok` / `warning` / `broken`) with **actionable
recommendations**.

The three previous DevTools features (traces, diffs, validation)
exposed raw data.  This one turns them into advice: "This entity is
broken because `hvac_work_mode` is sent as STRING, but Sber requires
ENUM — open the Schema Validation tab for details."

## Rules (8 independent functions)

| Code | Severity | Meaning |
|------|----------|---------|
| `not_known_to_bridge` | error | Entity not loaded. |
| `not_enabled` | error | Loaded but not published. |
| `linked_sensor` | info | Redirect user to the primary device. |
| `not_filled_by_state` | warning | HA has not populated state. |
| `never_acknowledged` | error | Sber silent rejection. |
| `validation_errors` | error | Schema errors on last publish. |
| `validation_warnings` | warning | Spec drift. |
| `recent_trace_failed` | error | Last command trace ended failed. |
| `recent_trace_timeout` | warning | Trace closed without publish. |

Verdict is the worst severity.  Adding a new heuristic is a single
function — the orchestrator just iterates `_RULES`.

## Architecture

- **`diagnostics_advisor.py`** — pure function
  `diagnose_entity(bridge, entity_id) -> DiagnosticReport`.  No
  timers, no side effects — just reads bridge state.
- **WebSocket API (1 command):** `diagnose_entity` — request/response,
  no subscribe channel (diagnostics are user-initiated, nothing to
  push).
- **UI** (`sber-diagnose.js`): entity_id input, verdict badge,
  findings list with severity dots and action hints, collapsible raw
  summary, and "Copy report" button for pasting into bug reports.

## Why this matters

Before: user sees "device doesn't work" → asks on GitHub → maintainer
asks for logs → back-and-forth for hours to narrow down.

After: user types the entity_id, clicks Diagnose, gets a verdict with
the root cause highlighted and clicks the specific tab suggested.
Bug reports include the copied report so maintainers have the full
picture upfront.

## Test plan

- [x] `pytest tests/hacs/` → 1881 passed (18 new: 15 unit, 3 WS)
- [x] `ruff check` + `ruff format` clean
- [x] Snapshots bumped to v1.36.0 (both locations)
- [ ] Manual: diagnose a healthy entity (expect clean verdict); break
      one feature type via DevTools inject, confirm validation_errors
      and failed_trace findings appear.

## DevTools roadmap status

All five planned DevTools features now merged: correlation timeline
(#27), state diffs (#28), replay / inject (#29), schema validation
(#30), and this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)