### PR TITLE
fix: MQTT-цикл больше не задерживает старт HA (v1.43.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.43.1] - 2026-08-08
+
+### Fixed
+
+- **Долгий старт Home Assistant.** MQTT-цикл подключения планировался
+  через `hass.async_create_task`, а такие задачи Home Assistant
+  отслеживает и дожидается в `async_block_till_done` — том самом
+  примитиве, который использует bootstrap. Цикл по определению
+  бесконечный, поэтому запуск HA простаивал до срабатывания таймаута
+  установки (`Setup timed out for bootstrap waiting on ...
+  _mqtt_connection_loop - moving forward`). Цикл переведён на
+  `hass.async_create_background_task`, который явно исключён из
+  `async_block_till_done` и отменяется при остановке HA. Регресс внесён
+  в v1.43.0 при исправлении «потерянных» исключений фоновых задач: до
+  него использовался `asyncio.create_task`, невидимый для HA. Добавлен
+  тест, воспроизводящий залипание через `async_block_till_done`.
+
 ## [1.43.0] - 2026-08-08
 
 Результат полного конкурентного code review (отчёт:

--- a/custom_components/sber_mqtt_bridge/manifest.json
+++ b/custom_components/sber_mqtt_bridge/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/dzerik/sber-mqtt-bridge/issues",
   "loggers": ["aiomqtt"],
   "requirements": ["aiomqtt>=2.0,<3.0", "pydantic>=2.0,<3.0"],
-  "version": "1.43.0"
+  "version": "1.43.1"
 }

--- a/custom_components/sber_mqtt_bridge/sber_bridge.py
+++ b/custom_components/sber_mqtt_bridge/sber_bridge.py
@@ -519,22 +519,19 @@ class SberBridge:
         """Public wrapper for forcing a device config republish to Sber."""
         await self._publish_config()
 
-    def _create_safe_task(self, coro: Any, *, name: str | None = None) -> asyncio.Task:
-        """Create an asyncio task with error logging to prevent silent failures.
+    def _attach_error_logger(self, task: asyncio.Task, name: str | None) -> asyncio.Task:
+        """Log any unhandled exception of ``task`` instead of losing it.
 
-        Wraps ``hass.async_create_task`` with a done-callback that logs any
-        unhandled exception at WARNING level.  This prevents the class of bugs
-        where a fire-and-forget publish task silently drops a state update
-        (similar to issue #3).
+        Without this, a failing fire-and-forget task surfaces only as
+        asyncio's ``Task exception was never retrieved`` at GC time.
 
         Args:
-            coro: Coroutine to schedule.
-            name: Optional task name for log messages.
+            task: Task to observe.
+            name: Human-readable name used in the log message.
 
         Returns:
-            The created asyncio task; callers may store it for cancellation.
+            The same task, for call chaining.
         """
-        task = self._hass.async_create_task(coro, eager_start=True)
 
         def _done_cb(t: asyncio.Task) -> None:
             if t.cancelled():
@@ -550,6 +547,48 @@ class SberBridge:
 
         task.add_done_callback(_done_cb)
         return task
+
+    def _create_safe_task(self, coro: Any, *, name: str | None = None) -> asyncio.Task:
+        """Create a SHORT-LIVED tracked task with error logging.
+
+        Use for work that finishes on its own (debounced publish, delayed
+        confirm).  These are tracked by Home Assistant, so
+        ``async_block_till_done`` — and therefore tests and shutdown —
+        wait for them, which is what we want for short work.
+
+        Do NOT use for loops that run for the lifetime of the entry: a
+        tracked never-ending task blocks HA bootstrap until it times out.
+        Use :meth:`_create_daemon_task` instead.
+
+        Args:
+            coro: Coroutine to schedule.
+            name: Optional task name for log messages.
+
+        Returns:
+            The created asyncio task; callers may store it for cancellation.
+        """
+        return self._attach_error_logger(self._hass.async_create_task(coro, eager_start=True), name)
+
+    def _create_daemon_task(self, coro: Any, *, name: str) -> asyncio.Task:
+        """Create a LONG-RUNNING background task with error logging.
+
+        ``hass.async_create_background_task`` is explicitly excluded from
+        ``async_block_till_done`` and is cancelled on HA shutdown, so a
+        never-ending loop scheduled this way does not hold up startup.
+
+        This matters: the MQTT connection loop runs forever by design, and
+        scheduling it as a tracked task made HA's bootstrap wait on it until
+        the setup timeout fired ("Setup timed out for bootstrap waiting on
+        ... _mqtt_connection_loop - moving forward"), delaying every start.
+
+        Args:
+            coro: Coroutine to schedule.
+            name: Task name (required — it shows up in HA diagnostics).
+
+        Returns:
+            The created asyncio task; callers may store it for cancellation.
+        """
+        return self._attach_error_logger(self._hass.async_create_background_task(coro, name, eager_start=True), name)
 
     @property
     def message_log(self) -> list[dict[str, Any]]:
@@ -774,7 +813,9 @@ class SberBridge:
         self._ha_instance_id_prefix: str = full_uuid[:8]
         self._load_exposed_entities()
         self._subscribe_ha_events()
-        self._connection_task = self._create_safe_task(
+        # Daemon, not a tracked task: this loop never returns, so tracking it
+        # would make HA bootstrap wait on it until the setup timeout.
+        self._connection_task = self._create_daemon_task(
             self._mqtt_connection_loop(),
             name="mqtt_connection_loop",
         )

--- a/custom_components/sber_mqtt_bridge/sber_protocol.py
+++ b/custom_components/sber_mqtt_bridge/sber_protocol.py
@@ -16,7 +16,7 @@ from .sber_models import validate_config_payload, validate_device, validate_stat
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = "1.43.0"
+VERSION = "1.43.1"
 """Protocol version string included in the hub device descriptor."""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sber-mqtt-bridge"
-version = "1.43.0"
+version = "1.43.1"
 description = "Sber Smart Home MQTT Bridge for Home Assistant"
 requires-python = ">=3.13"
 license = "MIT"

--- a/tests/hacs/test_bridge_lifecycle.py
+++ b/tests/hacs/test_bridge_lifecycle.py
@@ -415,6 +415,46 @@ async def test_connection_loop_crash_is_logged_not_lost(hass: HomeAssistant, cap
     await bridge.async_stop()
 
 
+async def test_connection_loop_does_not_block_startup(hass: HomeAssistant) -> None:
+    """The never-ending MQTT loop must not hold up HA bootstrap.
+
+    Regression guard for a real startup stall: the loop was scheduled with
+    ``hass.async_create_task``, which Home Assistant tracks and awaits in
+    ``async_block_till_done``.  Since the loop runs forever, bootstrap sat
+    on it until the setup timeout fired ("Setup timed out for bootstrap
+    waiting on ... _mqtt_connection_loop - moving forward") and every HA
+    start was delayed by that timeout.
+
+    ``async_block_till_done`` is exactly the primitive bootstrap uses, so
+    asserting that it returns while the loop is still running reproduces
+    the stall directly: with a tracked task this call never comes back.
+    """
+    entry = _make_entry(hass)
+    bridge = SberBridge(hass, entry)
+
+    never_ends = asyncio.Event()
+
+    async def _run_forever(*_args: object, **_kwargs: object) -> None:
+        await never_ends.wait()
+
+    bridge._mqtt_service.run = _run_forever
+
+    await bridge.async_start()
+
+    # Must not hang: a tracked (non-background) task makes this await the loop.
+    async with asyncio.timeout(5):
+        await hass.async_block_till_done()
+
+    assert bridge._connection_task is not None
+    assert not bridge._connection_task.done(), "precondition: the loop must still be running"
+    assert bridge._connection_task in hass._background_tasks, (
+        "the MQTT loop must be a background task — tracked tasks block HA bootstrap"
+    )
+
+    never_ends.set()
+    await bridge.async_stop()
+
+
 # ---------------------------------------------------------------------------
 # Payload-size guard + handler isolation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Симптом

В логах пользователя:

```
WARNING [homeassistant.bootstrap] Setup timed out for bootstrap waiting on
{<Task pending coro=<SberBridge._mqtt_connection_loop()
 running at custom_components/sber_mqtt_bridge/sber_bridge.py:926>>} - moving forward
```

Каждый старт Home Assistant простаивал до срабатывания таймаута установки.

## Причина

Цикл подключения планировался через `hass.async_create_task`. Такие задачи HA **отслеживает** и дожидается в `async_block_till_done` — том самом примитиве, который вызывает bootstrap. Цикл бесконечный по определению, поэтому ожидание всегда упиралось в таймаут.

**Регресс из v1.43.0, внесён мной.** Волна 1 ремедиации переводила задачу с `asyncio.create_task` (невидимого для HA — отсюда «Task exception was never retrieved») на `hass.async_create_task`. Проблема была реальной, но API выбран неверный.

## Решение

`hass.async_create_background_task` — даёт то же логирование исключений, но, по документации HA, «Will not block startup», исключён из `async_block_till_done` и отменяется при остановке.

`_create_safe_task` разделён на два метода с явными докстрингами, когда какой применять:
- короткие задачи (debounce-публикация, delayed confirm) остаются отслеживаемыми — ожидание в тестах и при выключении для них корректно;
- долгоживущие циклы идут через `_create_daemon_task`.

## Проверка

`test_connection_loop_does_not_block_startup` воспроизводит залипание напрямую: с отслеживаемой задачей `async_block_till_done` не возвращается.

Мутационная проба на изолированной копии — возврат на `_create_safe_task` роняет тест по таймауту.

```
3375 passed, coverage 96.58%, ruff clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)